### PR TITLE
Prep reversee-mcp for npm publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Reversee ships an MCP server so LLM agents can drive it. With the Reversee app r
 **Claude Code** — one line:
 
 ```sh
-claude mcp add reversee -- npx reversee-mcp
+claude mcp add reversee -- npx -y reversee-mcp
 ```
 
 **Cursor** — add to `~/.cursor/mcp.json`:
@@ -43,7 +43,7 @@ claude mcp add reversee -- npx reversee-mcp
 ```json
 {
   "mcpServers": {
-    "reversee": { "command": "npx", "args": ["reversee-mcp"] }
+    "reversee": { "command": "npx", "args": ["-y", "reversee-mcp"] }
   }
 }
 ```

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,54 @@
+# reversee-mcp
+
+MCP server for [Reversee](https://github.com/galusben/reversee), the reverse-proxy web debugger. Lets MCP clients like Claude Code and Cursor inspect and (optionally) control a running Reversee app: read captured HTTP traffic, check and change the proxy configuration, and start/stop the proxy.
+
+## Setup
+
+Launch the Reversee app, then:
+
+**Claude Code**
+
+```sh
+claude mcp add reversee -- npx -y reversee-mcp
+```
+
+**Cursor** — add to `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "reversee": { "command": "npx", "args": ["-y", "reversee-mcp"] }
+  }
+}
+```
+
+## Tools
+
+| Tool | Description |
+| --- | --- |
+| `get_status` | App version, proxy state, listen/destination config, traffic count |
+| `get_config` | Read the proxy configuration |
+| `update_config` | Change the configuration (gated, see below) |
+| `start_proxy` / `stop_proxy` / `restart_proxy` | Control the proxy (gated) |
+| `list_traffic` | Captured requests, paged, bodies elided |
+| `get_traffic_entry` | One request in full: headers, bodies, timings, curl command |
+| `list_breakpoints` | Configured breakpoint rules |
+| `validate_setup` | Setup checks: destination, ports, root cert, proxy process |
+| `export_diagnostics` | Versions, platform, settings, state — for bug reports |
+
+## Security model
+
+- The bridge talks to the app over a **local unix domain socket / Windows named pipe** with a per-boot token — never a TCP port. Only your user account can reach it.
+- **Read-only by default.** The mutating tools (`start_proxy`, `stop_proxy`, `restart_proxy`, `update_config`) are rejected until you check *Proxy Settings → Allow MCP to Control the Proxy* in the Reversee app.
+- *Proxy Settings → Enable MCP Integration* in the app turns the socket off entirely.
+
+If Reversee is not running, every tool returns a clear "launch the app" message.
+
+## Requirements
+
+- Node 20+
+- Reversee 2.0+ running locally
+
+## License
+
+MIT

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -2,7 +2,7 @@
 // reversee-mcp: stdio MCP server bridging Claude Code / Cursor to a running
 // Reversee app over its local control socket.
 //
-// One-line setup:   claude mcp add reversee -- npx reversee-mcp
+// One-line setup:   claude mcp add reversee -- npx -y reversee-mcp
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -17,7 +17,7 @@ import { certificateTrustDialog, exportRootCert } from './certs/certs';
 import { checkForUpdatesInteractive } from './updater';
 
 const HOMEPAGE = 'https://github.com/galusben/reversee';
-const MCP_SETUP_COMMAND = 'claude mcp add reversee -- npx reversee-mcp';
+const MCP_SETUP_COMMAND = 'claude mcp add reversee -- npx -y reversee-mcp';
 
 export function createMenu(
   win: BrowserWindow,
@@ -164,7 +164,7 @@ export function createMenu(
               message: 'MCP setup command copied to clipboard',
               detail:
                 `Run this in your terminal:\n\n${MCP_SETUP_COMMAND}\n\n` +
-                'For Cursor, add reversee with command "npx" and args ["reversee-mcp"] ' +
+                'For Cursor, add reversee with command "npx" and args ["-y", "reversee-mcp"] ' +
                 'to ~/.cursor/mcp.json. See the README for details.',
             });
           },


### PR DESCRIPTION
Adds the mcp/ package README (the npm package page) and switches all setup commands to `npx -y reversee-mcp` — without `-y`, npx prompts before first download and hangs a headless MCP client spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)