### PR TITLE
Install methods: brew tap + curl installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,27 @@ Reversee sits between your client and a destination server. Point your client at
 - **Redirect & host rewriting** — keep redirect chains and Host headers pointed at the proxy.
 - **MCP integration** — let Claude Code, Cursor, or any MCP client inspect and (optionally) control the proxy. See below.
 
+## Install
+
+**macOS (Homebrew):**
+
+```sh
+brew install --cask galusben/reversee/reversee
+```
+
+**macOS / Linux (one-liner):**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/galusben/reversee/main/install.sh | bash
+```
+
+**Windows / manual:** download the installer for your OS from [Releases](https://github.com/galusben/reversee/releases).
+
+macOS builds are signed and notarized; the app updates itself from GitHub Releases.
+
 ## Getting started
 
-1. Download the build for your OS from [Releases](https://github.com/galusben/reversee/releases) and launch it.
+1. Install and launch Reversee.
 2. Pick a listen protocol and port (ports below 1024 need admin/root).
 3. Pick the destination protocol, host, and port.
 4. Click **Start**.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Reversee installer for macOS and Linux.
+#   curl -fsSL https://raw.githubusercontent.com/galusben/reversee/main/install.sh | bash
+# Downloads the latest release from GitHub and installs it:
+#   macOS: Reversee.app into /Applications (or ~/Applications)
+#   Linux: AppImage into ~/.local/bin/reversee
+set -eu
+
+REPO="galusben/reversee"
+API="https://api.github.com/repos/$REPO/releases/latest"
+
+say() { printf '%s\n' "$*"; }
+fail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+asset_url() {
+  # Prints the browser_download_url of the first asset matching $1.
+  curl -fsSL "$API" | grep '"browser_download_url"' | grep -- "$1" | head -1 | sed 's/.*"\(https[^"]*\)".*/\1/'
+}
+
+OS=$(uname -s)
+ARCH=$(uname -m)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+case "$OS" in
+  Darwin)
+    case "$ARCH" in
+      arm64) PATTERN='arm64-mac\.zip"' ;;
+      x86_64) PATTERN='[0-9]-mac\.zip"' ;; # the x64 zip has no arch infix
+      *) fail "unsupported macOS architecture: $ARCH" ;;
+    esac
+    URL=$(asset_url "$PATTERN")
+    [ -n "$URL" ] || fail "could not find a macOS asset in the latest release"
+    say "Downloading $URL"
+    curl -fSL --progress-bar "$URL" -o "$TMP/reversee.zip"
+
+    DEST="/Applications"
+    [ -w "$DEST" ] || DEST="$HOME/Applications"
+    mkdir -p "$DEST"
+    rm -rf "$DEST/Reversee.app"
+    ditto -x -k "$TMP/reversee.zip" "$DEST"
+    say "Installed $DEST/Reversee.app"
+    say "Launch it with: open '$DEST/Reversee.app'"
+    ;;
+  Linux)
+    case "$ARCH" in
+      x86_64) ;;
+      *) fail "no prebuilt Linux binary for $ARCH yet (build from source: https://github.com/$REPO)" ;;
+    esac
+    URL=$(asset_url '\.AppImage"')
+    [ -n "$URL" ] || fail "could not find a Linux AppImage in the latest release"
+    say "Downloading $URL"
+    BIN_DIR="$HOME/.local/bin"
+    mkdir -p "$BIN_DIR"
+    curl -fSL --progress-bar "$URL" -o "$BIN_DIR/reversee"
+    chmod +x "$BIN_DIR/reversee"
+    say "Installed $BIN_DIR/reversee"
+    case ":$PATH:" in
+      *":$BIN_DIR:"*) say "Run it with: reversee" ;;
+      *) say "Note: $BIN_DIR is not on your PATH. Run it with: $BIN_DIR/reversee" ;;
+    esac
+    say "(AppImages need FUSE; on most distros it is preinstalled.)"
+    ;;
+  *)
+    fail "unsupported OS: $OS (Windows builds are on https://github.com/$REPO/releases)"
+    ;;
+esac


### PR DESCRIPTION
Adds install.sh (macOS/Linux one-liner installer fetching the latest GitHub release by OS/arch) and an Install section in the README: Homebrew cask via the galusben/reversee tap, the curl one-liner, and manual downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)