### PR TITLE
Release pipeline: verify signed mac artifacts + auto-update Homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,12 @@ on:
 env:
   NODE_OPTIONS: --max-old-space-size=4096
 
+# build (draft) -> verify the signed mac artifacts -> promote (publish + brew).
+# Nothing goes live until the signed, notarized macOS app has been downloaded
+# from the release, Gatekeeper-checked, installed, and smoke-tested.
 jobs:
-  release:
-    name: Build and publish (${{ matrix.os }})
+  build:
+    name: Build & publish draft (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
@@ -25,10 +28,10 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      # Signing/notarization activate only when the secrets exist:
-      #   mac: CSC_LINK + CSC_KEY_PASSWORD (+ APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD,
-      #        APPLE_TEAM_ID for notarization)
-      #   win: CSC_LINK + CSC_KEY_PASSWORD
+      # electron-builder creates the GitHub release as a draft; each matrix leg
+      # attaches its artifacts to the same draft. Signing/notarization activate
+      # only when the secrets exist (mac: CSC_LINK + CSC_KEY_PASSWORD, and the
+      # APPLE_* trio for notarization).
       - run: npx electron-builder --publish=always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -38,3 +41,93 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ secrets.CSC_LINK != '' }}
+
+  verify-mac:
+    name: Verify signed macOS artifacts
+    needs: build
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VERSION: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Download macOS artifacts from the draft release
+        run: |
+          VER="${VERSION#v}"
+          mkdir -p dl
+          gh release download "$VERSION" --repo "$GITHUB_REPOSITORY" --dir dl \
+            --pattern "Reversee-${VER}-arm64.dmg" \
+            --pattern "Reversee-${VER}.dmg" \
+            --pattern "Reversee-${VER}-arm64-mac.zip"
+          ls -la dl
+      - name: Verify signature, notarization and Gatekeeper on both dmgs
+        run: |
+          VER="${VERSION#v}"
+          check_app() {
+            app="$1"
+            echo "::group::codesign/notarization: $app"
+            codesign --verify --deep --strict --verbose=2 "$app"
+            codesign -dv --verbose=4 "$app" 2>&1 | grep -E 'TeamIdentifier|flags='
+            xcrun stapler validate "$app"
+            spctl -a -t exec -vvv "$app" 2>&1 | grep -E 'source=Notarized Developer ID|origin='
+            echo "::endgroup::"
+          }
+          for dmg in "dl/Reversee-${VER}-arm64.dmg" "dl/Reversee-${VER}.dmg"; do
+            mp="$(mktemp -d)"
+            hdiutil attach "$dmg" -nobrowse -mountpoint "$mp" >/dev/null
+            check_app "$mp/Reversee.app"
+            hdiutil detach "$mp" >/dev/null
+          done
+      - name: Install and smoke-test the signed app
+        run: |
+          VER="${VERSION#v}"
+          ditto -x -k "dl/Reversee-${VER}-arm64-mac.zip" installed
+          # Gatekeeper must accept the extracted app with no quarantine override.
+          spctl -a -t exec -vvv "installed/Reversee.app"
+          REVERSEE_APP_BIN="$PWD/installed/Reversee.app/Contents/MacOS/Reversee" \
+          REVERSEE_EXPECTED_VERSION="$VER" \
+            npx playwright test -c playwright.smoke.config.ts
+
+  promote:
+    name: Publish release & update Homebrew
+    needs: verify-mac
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VERSION: ${{ github.ref_name }}
+      HAS_TAP_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN != '' }}
+    steps:
+      - name: Publish the draft release
+        run: gh release edit "$VERSION" --repo "$GITHUB_REPOSITORY" --draft=false --latest
+
+      - uses: actions/checkout@v5
+      - name: Update the Homebrew cask
+        if: env.HAS_TAP_TOKEN == 'true'
+        env:
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        run: |
+          VER="${VERSION#v}"
+          mkdir -p casksrc && cd casksrc
+          gh release download "$VERSION" --repo "$GITHUB_REPOSITORY" \
+            --pattern "Reversee-${VER}-arm64.dmg" --pattern "Reversee-${VER}.dmg"
+          ARM_SHA=$(shasum -a 256 "Reversee-${VER}-arm64.dmg" | awk '{print $1}')
+          INTEL_SHA=$(shasum -a 256 "Reversee-${VER}.dmg" | awk '{print $1}')
+          cd ..
+
+          git clone "https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/galusben/homebrew-reversee.git" tap
+          sh scripts/render-cask.sh "$VER" "$ARM_SHA" "$INTEL_SHA" > tap/Casks/reversee.rb
+          cd tap
+          if git diff --quiet; then echo "cask already up to date"; exit 0; fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -aqm "Reversee ${VER}"
+          git push -q

--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ Reversee sits between your client and a destination server. Point your client at
 **macOS (Homebrew):**
 
 ```sh
-brew install --cask galusben/reversee/reversee
+brew tap galusben/reversee
+brew install --cask reversee
 ```
+
+If Homebrew reports the tap is untrusted, run `brew trust galusben/reversee` once and re-run the install.
 
 **macOS / Linux (one-liner):**
 

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+// Separate config: the smoke suite drives the FINAL packaged app (via
+// REVERSEE_APP_BIN), not the dev build that playwright.config.ts uses.
+export default defineConfig({
+  testDir: 'tests/smoke',
+  workers: 1,
+  retries: 1,
+  timeout: 90_000,
+  reporter: 'list',
+});

--- a/scripts/render-cask.sh
+++ b/scripts/render-cask.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Renders the Homebrew cask for a given version + dmg checksums.
+# Usage: render-cask.sh <version> <arm64_sha256> <intel_sha256>
+set -eu
+
+VERSION="$1"
+ARM_SHA="$2"
+INTEL_SHA="$3"
+
+cat <<EOF
+cask "reversee" do
+  arch arm: "-arm64", intel: ""
+
+  version "${VERSION}"
+  sha256 arm:   "${ARM_SHA}",
+         intel: "${INTEL_SHA}"
+
+  url "https://github.com/galusben/reversee/releases/download/v#{version}/Reversee-#{version}#{arch}.dmg"
+  name "Reversee"
+  desc "Reverse-proxy web debugger"
+  homepage "https://github.com/galusben/reversee"
+
+  auto_updates true
+
+  app "Reversee.app"
+
+  zap trash: [
+    "~/Library/Application Support/Reversee",
+    "~/Library/Logs/Reversee",
+    "~/Library/Preferences/ninja.reversee.plist",
+    "~/Library/Saved Application State/ninja.reversee.savedState",
+  ]
+end
+EOF

--- a/tests/smoke/packaged.spec.ts
+++ b/tests/smoke/packaged.spec.ts
@@ -1,0 +1,43 @@
+// Smoke test for the FINAL packaged, signed app (not the dev build). The
+// release pipeline downloads the published artifact, installs it, and points
+// REVERSEE_APP_BIN at the app executable inside the bundle.
+import { test, expect, _electron as electron } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const APP_BIN = process.env.REVERSEE_APP_BIN;
+const EXPECTED_VERSION = process.env.REVERSEE_EXPECTED_VERSION;
+
+test('packaged app launches, exposes the API, reports the expected version', async () => {
+  expect(APP_BIN, 'REVERSEE_APP_BIN must point at the packaged app executable').toBeTruthy();
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reversee-smoke-'));
+
+  const app = await electron.launch({
+    executablePath: APP_BIN!,
+    args: [],
+    env: { ...process.env, REVERSEE_USER_DATA: userDataDir, NODE_ENV: 'production' },
+  });
+
+  try {
+    const page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    // Window is real and the secure preload bridge is present.
+    await expect(page.getByText(/Proxy stopped/)).toBeVisible({ timeout: 30_000 });
+    expect(await page.evaluate(() => typeof (window as never)['require'])).toBe('undefined');
+    expect(await page.evaluate(() => typeof (window as { reversee?: unknown }).reversee)).toBe(
+      'object'
+    );
+
+    const version = await page.evaluate(() => (window as { reversee: { getVersion(): Promise<string> } }).reversee.getVersion());
+    if (EXPECTED_VERSION) {
+      expect(version).toBe(EXPECTED_VERSION);
+    } else {
+      expect(version).toMatch(/^\d+\.\d+\.\d+/);
+    }
+  } finally {
+    await app.close();
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Makes the brew cask part of the regular release flow and adds gated verification of the signed macOS build, per request.

`release.yml` becomes a **draft → verify → promote** pipeline:

1. **build** (mac/win/linux matrix) — electron-builder signs + notarizes and publishes a **draft** GitHub release.
2. **verify-mac** — downloads the signed dmgs/zip *from the draft release* (the real final bytes), verifies `codesign` + notarization staple + Gatekeeper acceptance on both dmgs, then installs and **smoke-tests the packaged app** (Playwright: window visible, preload API present, version matches the tag). The release cannot go live unless this passes.
3. **promote** — publishes the draft (un-draft, mark latest) and **updates the Homebrew cask** in `galusben/homebrew-reversee` (new version + per-arch dmg sha256), committed by CI.

New files: `tests/smoke/packaged.spec.ts`, `playwright.smoke.config.ts`, `scripts/render-cask.sh` (verified byte-identical to the currently published cask). README brew instructions updated for Homebrew's third-party-tap trust gate.

### Needs before brew automation activates
- A fine-grained PAT with **Contents: read/write on `homebrew-reversee` only**, added as repo secret **`TAP_GITHUB_TOKEN`**. The promote step no-ops without it, so this is safe to merge now.

### Scope note
S3 (`download.reversee.ninja`) is intentionally **not** in this recurring flow — it remains the one-time legacy bridge for 1.0.6 users. Say the word if you want every release mirrored to S3 too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)