### PR TITLE
MCP: app owns the tool catalog (bridge becomes a generic passthrough)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ The package is published as [`reversee-mcp`](https://www.npmjs.com/package/rever
 | `validate_setup` | Setup checks (destination, ports, root cert, proxy process) |
 | `export_diagnostics` | Versions, platform, settings, state — for bug reports |
 
+The app owns this list — it serves the catalog to the bridge at startup, so **tools added in an app update appear automatically** with no MCP-server reinstall (the bridge is a generic passthrough). When the app is not running, the bridge advertises a built-in fallback list and each call returns a "launch Reversee" message.
+
+### Updating the MCP server
+
+`npx` caches the server on first run and does not auto-upgrade it. You rarely need to update — new tools arrive via app updates — but if the app reports a newer `reversee-mcp` is recommended (in `get_status`), upgrade to latest and restart your MCP client:
+
+```sh
+for d in ~/.npm/_npx/*/; do [ -e "$d/node_modules/reversee-mcp" ] && rm -rf "$d"; done
+```
+
+This clears only Reversee's cached copy; the next run pulls the latest published version.
+
 ### Security model
 
 - The bridge talks to the app over a **local socket** (unix domain socket / Windows named pipe), never a TCP port, with a per-boot token — only your user account can reach it.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -36,6 +36,16 @@ claude mcp add reversee -- npx -y reversee-mcp
 | `validate_setup` | Setup checks: destination, ports, root cert, proxy process |
 | `export_diagnostics` | Versions, platform, settings, state — for bug reports |
 
+The Reversee app owns this list and serves it to the bridge at startup, so tools added in an app update appear automatically — this package rarely needs updating. When the app is not running, a built-in fallback list is advertised.
+
+## Updating
+
+`npx` caches this server and won't auto-upgrade it. If `get_status` reports a newer version is recommended, upgrade to latest and restart your MCP client:
+
+```sh
+for d in ~/.npm/_npx/*/; do [ -e "$d/node_modules/reversee-mcp" ] && rm -rf "$d"; done
+```
+
 ## Security model
 
 - The bridge talks to the app over a **local unix domain socket / Windows named pipe** with a per-boot token — never a TCP port. Only your user account can reach it.

--- a/mcp/src/catalog.ts
+++ b/mcp/src/catalog.ts
@@ -1,0 +1,96 @@
+// Catalog handling for the bridge. The app owns the authoritative catalog
+// (served via the `list_tools` control method); this module fetches it and
+// falls back to a frozen embedded copy only when the app is unreachable.
+import type { ReverseeClient } from './client.js';
+
+export interface ToolDef {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  mutating?: boolean;
+}
+
+export interface ResolvedCatalog {
+  tools: ToolDef[];
+  /** Bridge version the running app recommends; undefined when offline. */
+  recommendedBridge?: string;
+  /** True when the catalog came from the running app (vs the offline fallback). */
+  fromApp: boolean;
+}
+
+const noInput = { type: 'object', properties: {}, additionalProperties: false };
+
+// Frozen mirror of the app's catalog, used only when the app is not running so
+// the agent still sees a meaningful tool list. The app's copy is authoritative
+// whenever it is reachable, so drift here is harmless.
+export const FALLBACK_CATALOG: ToolDef[] = [
+  { name: 'get_status', description: 'Current Reversee state: app version, proxy running, config, traffic and breakpoint counts.', inputSchema: noInput },
+  { name: 'get_config', description: 'Full Reversee proxy configuration.', inputSchema: noInput },
+  {
+    name: 'update_config',
+    description: 'Update Reversee configuration (partial settings object). Requires "Allow MCP to Control the Proxy".',
+    inputSchema: { type: 'object', properties: { patch: { type: 'object' } }, required: ['patch'], additionalProperties: false },
+    mutating: true,
+  },
+  { name: 'start_proxy', description: 'Start the reverse proxy. Requires control enabled in the app.', inputSchema: noInput, mutating: true },
+  { name: 'stop_proxy', description: 'Stop the reverse proxy. Requires control enabled in the app.', inputSchema: noInput, mutating: true },
+  { name: 'restart_proxy', description: 'Restart the proxy worker. Requires control enabled in the app.', inputSchema: noInput, mutating: true },
+  {
+    name: 'list_traffic',
+    description: 'List captured requests (bodies elided).',
+    inputSchema: { type: 'object', properties: { offset: { type: 'integer', minimum: 0 }, limit: { type: 'integer', minimum: 1, maximum: 200 } }, additionalProperties: false },
+  },
+  {
+    name: 'get_traffic_entry',
+    description: 'Full details of one captured request: headers, bodies, timings, curl.',
+    inputSchema: { type: 'object', properties: { trafficId: { type: 'integer' } }, required: ['trafficId'], additionalProperties: false },
+  },
+  { name: 'list_breakpoints', description: 'List the configured breakpoint rules.', inputSchema: noInput },
+  { name: 'validate_setup', description: 'Run setup checks (destination, ports, root cert, proxy process).', inputSchema: noInput },
+  { name: 'export_diagnostics', description: 'Export diagnostics for bug reports.', inputSchema: noInput },
+];
+
+/** Fetches the catalog from the running app; falls back to the embedded copy. */
+export async function resolveCatalog(client: ReverseeClient): Promise<ResolvedCatalog> {
+  try {
+    const res = (await client.call('list_tools')) as {
+      tools?: ToolDef[];
+      recommendedBridge?: string;
+    };
+    if (res && Array.isArray(res.tools) && res.tools.length > 0) {
+      return { tools: res.tools, recommendedBridge: res.recommendedBridge, fromApp: true };
+    }
+  } catch {
+    // App not running, or an older app without list_tools — use the fallback.
+  }
+  return { tools: FALLBACK_CATALOG, fromApp: false };
+}
+
+/** Numeric semver-ish compare of the release core (ignores pre-release tags). */
+export function isOlder(a: string, b: string): boolean {
+  const core = (v: string) => v.split('-')[0].split('.').map((n) => parseInt(n, 10) || 0);
+  const [a0 = 0, a1 = 0, a2 = 0] = core(a);
+  const [b0 = 0, b1 = 0, b2 = 0] = core(b);
+  if (a0 !== b0) return a0 < b0;
+  if (a1 !== b1) return a1 < b1;
+  return a2 < b2;
+}
+
+/** Advisory appended to get_status when the bridge is older than recommended. */
+export function versionAdvisory(
+  bridgeVersion: string,
+  recommendedBridge: string | undefined
+): { upToDate: boolean; version: string; recommended?: string; note?: string } {
+  if (recommendedBridge && isOlder(bridgeVersion, recommendedBridge)) {
+    return {
+      upToDate: false,
+      version: bridgeVersion,
+      recommended: recommendedBridge,
+      note:
+        `A newer reversee-mcp (>= ${recommendedBridge}) is available; you are on ${bridgeVersion}. ` +
+        'Upgrade to latest by clearing the cached copy, then restart your MCP client:\n' +
+        '  for d in ~/.npm/_npx/*/; do [ -e "$d/node_modules/reversee-mcp" ] && rm -rf "$d"; done',
+    };
+  }
+  return { upToDate: true, version: bridgeVersion };
+}

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -2,124 +2,60 @@
 // reversee-mcp: stdio MCP server bridging Claude Code / Cursor to a running
 // Reversee app over its local control socket.
 //
-// One-line setup:   claude mcp add reversee -- npx -y reversee-mcp
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+//   claude mcp add reversee -- npx -y reversee-mcp
+//
+// The bridge is a generic proxy: the app owns the tool catalog (fetched at
+// startup via `list_tools`), so new tools shipped in an app update reach users
+// through their already-installed bridge. A frozen embedded catalog is used
+// only when the app is not running.
+import { createRequire } from 'node:module';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { z } from 'zod';
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { ReverseeClient } from './client.js';
+import { resolveCatalog, versionAdvisory } from './catalog.js';
+
+const BRIDGE_VERSION: string = createRequire(import.meta.url)('../package.json').version;
 
 const client = new ReverseeClient();
-const server = new McpServer({ name: 'reversee', version: '2.0.0' });
 
-type ToolResult = { content: Array<{ type: 'text'; text: string }>; isError?: boolean };
+// Snapshot the catalog at startup: if the app is up we advertise its tools, if
+// not we advertise the frozen fallback. (A running app launched later is picked
+// up on the next MCP client restart.)
+const catalog = await resolveCatalog(client);
 
-async function call(method: string, params?: unknown): Promise<ToolResult> {
+const server = new Server(
+  { name: 'reversee', version: BRIDGE_VERSION },
+  { capabilities: { tools: {} } }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: catalog.tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: t.inputSchema,
+  })),
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const { name, arguments: args } = req.params;
   try {
-    const result = await client.call(method, params);
-    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    // update_config takes its payload under `patch`; everything else forwards
+    // its arguments object straight through as the method params.
+    const params = name === 'update_config' ? (args?.['patch'] ?? {}) : args;
+    const result = await client.call(name, params);
+
+    // Surface an upgrade hint on get_status when the bridge is behind the
+    // version the running app recommends.
+    const payload =
+      name === 'get_status' && result && typeof result === 'object'
+        ? { ...(result as object), bridge: versionAdvisory(BRIDGE_VERSION, catalog.recommendedBridge) }
+        : result;
+
+    return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] };
   } catch (error) {
     return { content: [{ type: 'text', text: (error as Error).message }], isError: true };
   }
-}
-
-server.registerTool(
-  'get_status',
-  {
-    description:
-      'Current Reversee state: app version, whether the proxy is running, listen/destination config, traffic and breakpoint counts.',
-  },
-  () => call('get_status')
-);
-
-server.registerTool(
-  'get_config',
-  { description: 'Full Reversee proxy configuration (listen/destination, interceptors, rewrite flags).' },
-  () => call('get_config')
-);
-
-server.registerTool(
-  'update_config',
-  {
-    description:
-      'Update Reversee configuration. Accepts a partial settings object; unknown keys and invalid values are ignored. ' +
-      'Keys: listenProtocol/destProtocol (http|https), listenPort/destPort (1-65535), dest (host), ' +
-      'interceptRequest/interceptResponse (bool), requestInterceptor/responseInterceptor (JS source), ' +
-      'rewriteRedirects/rewriteHost/allowSelfSignedUpstream (bool). ' +
-      'Requires "Allow MCP to Control the Proxy" enabled in the app. Returns the resulting config.',
-    inputSchema: { patch: z.record(z.string(), z.unknown()).describe('Partial settings object') },
-  },
-  ({ patch }) => call('update_config', patch)
-);
-
-server.registerTool(
-  'start_proxy',
-  {
-    description:
-      'Start the reverse proxy with the current configuration. Requires control to be enabled in the app.',
-  },
-  () => call('start_proxy')
-);
-
-server.registerTool(
-  'stop_proxy',
-  { description: 'Stop the reverse proxy. Requires control to be enabled in the app.' },
-  () => call('stop_proxy')
-);
-
-server.registerTool(
-  'restart_proxy',
-  {
-    description:
-      'Restart the proxy worker process (also recovers from a wedged interceptor). Requires control to be enabled in the app.',
-  },
-  () => call('restart_proxy')
-);
-
-server.registerTool(
-  'list_traffic',
-  {
-    description:
-      'List captured requests (newest last): method, URL, status, content type, total time. Bodies are elided; use get_traffic_entry for full details.',
-    inputSchema: {
-      offset: z.number().int().min(0).optional().describe('Skip this many entries'),
-      limit: z.number().int().min(1).max(200).optional().describe('Max entries to return (default 50)'),
-    },
-  },
-  ({ offset, limit }) => call('list_traffic', { offset, limit })
-);
-
-server.registerTool(
-  'get_traffic_entry',
-  {
-    description:
-      'Full details of one captured request: headers, bodies, timings, and a copy-pasteable curl command.',
-    inputSchema: { trafficId: z.number().int().describe('Id from list_traffic') },
-  },
-  ({ trafficId }) => call('get_traffic_entry', { trafficId })
-);
-
-server.registerTool(
-  'list_breakpoints',
-  { description: 'List the configured breakpoint rules (URL regex + HTTP methods).' },
-  () => call('list_breakpoints')
-);
-
-server.registerTool(
-  'validate_setup',
-  {
-    description:
-      'Run setup checks: destination configured, ports valid, root certificate present, proxy process state.',
-  },
-  () => call('validate_setup')
-);
-
-server.registerTool(
-  'export_diagnostics',
-  {
-    description:
-      'Export diagnostics: versions, platform, full settings, proxy state, traffic count, breakpoints, log location.',
-  },
-  () => call('export_diagnostics')
-);
+});
 
 await server.connect(new StdioServerTransport());

--- a/src/main/mcp/catalog.ts
+++ b/src/main/mcp/catalog.ts
@@ -1,0 +1,118 @@
+// The authoritative MCP tool catalog, owned by the app. The bridge fetches
+// this at startup (via the `list_tools` control method) and registers exactly
+// these tools, so adding or changing a tool here reaches users through their
+// already-installed bridge — no bridge republish needed. The bridge keeps its
+// own frozen copy only as an offline fallback.
+//
+// `inputSchema` is a JSON Schema (what MCP's tools/list expects). Keep this
+// module dependency-free so it can be unit-tested headlessly.
+
+export interface McpToolDef {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  /** Rejected unless the user enables "Allow MCP to Control the Proxy". */
+  mutating?: boolean;
+}
+
+const noInput = { type: 'object', properties: {}, additionalProperties: false };
+
+/**
+ * Bumped when we ship a bridge with capabilities the app relies on. The bridge
+ * compares its own version against this and advises the user to upgrade if it
+ * is older. No npm registry calls are involved.
+ */
+export const RECOMMENDED_BRIDGE_VERSION = '2.0.0';
+
+export const MCP_TOOL_CATALOG: McpToolDef[] = [
+  {
+    name: 'get_status',
+    description:
+      'Current Reversee state: app version, whether the proxy is running, listen/destination config, traffic and breakpoint counts.',
+    inputSchema: noInput,
+  },
+  {
+    name: 'get_config',
+    description: 'Full Reversee proxy configuration (listen/destination, interceptors, rewrite flags).',
+    inputSchema: noInput,
+  },
+  {
+    name: 'update_config',
+    description:
+      'Update Reversee configuration. Accepts a partial settings object; unknown keys and invalid values are ignored. ' +
+      'Keys: listenProtocol/destProtocol (http|https), listenPort/destPort (1-65535), dest (host), ' +
+      'interceptRequest/interceptResponse (bool), requestInterceptor/responseInterceptor (JS source), ' +
+      'rewriteRedirects/rewriteHost/allowSelfSignedUpstream (bool). ' +
+      'Requires "Allow MCP to Control the Proxy" enabled in the app. Returns the resulting config.',
+    inputSchema: {
+      type: 'object',
+      properties: { patch: { type: 'object', description: 'Partial settings object' } },
+      required: ['patch'],
+      additionalProperties: false,
+    },
+    mutating: true,
+  },
+  {
+    name: 'start_proxy',
+    description: 'Start the reverse proxy with the current configuration. Requires control to be enabled in the app.',
+    inputSchema: noInput,
+    mutating: true,
+  },
+  {
+    name: 'stop_proxy',
+    description: 'Stop the reverse proxy. Requires control to be enabled in the app.',
+    inputSchema: noInput,
+    mutating: true,
+  },
+  {
+    name: 'restart_proxy',
+    description:
+      'Restart the proxy worker process (also recovers from a wedged interceptor). Requires control to be enabled in the app.',
+    inputSchema: noInput,
+    mutating: true,
+  },
+  {
+    name: 'list_traffic',
+    description:
+      'List captured requests (newest last): method, URL, status, content type, total time. Bodies are elided; use get_traffic_entry for full details.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        offset: { type: 'integer', minimum: 0, description: 'Skip this many entries' },
+        limit: { type: 'integer', minimum: 1, maximum: 200, description: 'Max entries to return (default 50)' },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'get_traffic_entry',
+    description: 'Full details of one captured request: headers, bodies, timings, and a copy-pasteable curl command.',
+    inputSchema: {
+      type: 'object',
+      properties: { trafficId: { type: 'integer', description: 'Id from list_traffic' } },
+      required: ['trafficId'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'list_breakpoints',
+    description: 'List the configured breakpoint rules (URL regex + HTTP methods).',
+    inputSchema: noInput,
+  },
+  {
+    name: 'validate_setup',
+    description: 'Run setup checks: destination configured, ports valid, root certificate present, proxy process state.',
+    inputSchema: noInput,
+  },
+  {
+    name: 'export_diagnostics',
+    description:
+      'Export diagnostics: versions, platform, full settings, proxy state, traffic count, breakpoints, log location.',
+    inputSchema: noInput,
+  },
+];
+
+/** Tools rejected unless the user enables "Allow MCP to Control the Proxy". Derived from the catalog. */
+export const MCP_MUTATING_METHODS: ReadonlySet<string> = new Set(
+  MCP_TOOL_CATALOG.filter((t) => t.mutating).map((t) => t.name)
+);

--- a/src/main/mcp/handlers.ts
+++ b/src/main/mcp/handlers.ts
@@ -3,18 +3,14 @@
 import { app } from 'electron';
 import { getSettings, setSettings, getRootCertPem } from '../settings';
 import { isValidPort } from '../../shared/settings-schema';
+import { MCP_TOOL_CATALOG, MCP_MUTATING_METHODS, RECOMMENDED_BRIDGE_VERSION } from './catalog';
 import type { ControlHandler } from './control-server';
 import type { ProxyHost } from '../proxy-host';
 import type { TrafficStore } from '../traffic-store';
 import type { StartProxyResult } from '../../shared/ipc';
 import type { BreakpointRule, TrafficEntry } from '../../shared/types';
 
-export const MCP_MUTATING_METHODS: ReadonlySet<string> = new Set([
-  'start_proxy',
-  'stop_proxy',
-  'restart_proxy',
-  'update_config',
-]);
+export { MCP_MUTATING_METHODS };
 
 export interface McpHandlerContext {
   proxyHost: ProxyHost;
@@ -43,6 +39,14 @@ function trafficSummary(entry: TrafficEntry): Record<string, unknown> {
 
 export function createMcpHandlers(ctx: McpHandlerContext): Record<string, ControlHandler> {
   return {
+    // The bridge calls this at startup to learn which tools to advertise and
+    // which bridge version the app recommends. The app is the source of truth
+    // for the tool catalog.
+    list_tools: () => ({
+      tools: MCP_TOOL_CATALOG,
+      recommendedBridge: RECOMMENDED_BRIDGE_VERSION,
+    }),
+
     get_status: () => {
       const settings = getSettings();
       return {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -165,7 +165,9 @@ export function createMenu(
               detail:
                 `Run this in your terminal:\n\n${MCP_SETUP_COMMAND}\n\n` +
                 'For Cursor, add reversee with command "npx" and args ["-y", "reversee-mcp"] ' +
-                'to ~/.cursor/mcp.json. See the README for details.',
+                'to ~/.cursor/mcp.json.\n\n' +
+                'New tools arrive automatically with app updates. To upgrade the MCP ' +
+                'server itself, see "Updating the MCP server" in the README.',
             });
           },
         },

--- a/tests/unit/mcp-bridge.test.mjs
+++ b/tests/unit/mcp-bridge.test.mjs
@@ -1,0 +1,88 @@
+// Bridge catalog resolution + version-advisory logic, plus an integration
+// check of resolveCatalog against the real control-server implementation.
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { startControlServer } from '../../src/main/mcp/control-server';
+import { ReverseeClient } from '../../mcp/src/client';
+import {
+  resolveCatalog,
+  versionAdvisory,
+  isOlder,
+  FALLBACK_CATALOG,
+} from '../../mcp/src/catalog';
+
+describe('isOlder', () => {
+  it('compares release cores numerically', () => {
+    expect(isOlder('2.0.0', '2.1.0')).toBe(true);
+    expect(isOlder('2.0.0', '2.0.1')).toBe(true);
+    expect(isOlder('1.9.9', '2.0.0')).toBe(true);
+    expect(isOlder('2.0.0', '2.0.0')).toBe(false);
+    expect(isOlder('2.1.0', '2.0.0')).toBe(false);
+    expect(isOlder('10.0.0', '9.0.0')).toBe(false); // numeric, not lexical
+  });
+
+  it('ignores pre-release suffixes', () => {
+    expect(isOlder('2.0.0-beta.1', '2.0.0')).toBe(false);
+  });
+});
+
+describe('versionAdvisory', () => {
+  it('flags an out-of-date bridge with an upgrade note', () => {
+    const a = versionAdvisory('2.0.0', '2.1.0');
+    expect(a.upToDate).toBe(false);
+    expect(a.recommended).toBe('2.1.0');
+    expect(a.note).toMatch(/reversee-mcp/);
+    expect(a.note).toMatch(/_npx/); // contains the surgical refresh command
+  });
+
+  it('reports up to date when current or ahead', () => {
+    expect(versionAdvisory('2.1.0', '2.1.0').upToDate).toBe(true);
+    expect(versionAdvisory('2.2.0', '2.1.0').upToDate).toBe(true);
+  });
+
+  it('reports up to date when the app gives no recommendation (offline)', () => {
+    expect(versionAdvisory('2.0.0', undefined).upToDate).toBe(true);
+  });
+});
+
+describe('resolveCatalog', () => {
+  let dir;
+  let server;
+
+  afterEach(async () => {
+    await server?.close();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    server = undefined;
+  });
+
+  it('uses the app catalog when the app is reachable', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rev-cat-'));
+    server = await startControlServer({
+      dir,
+      appVersion: '0.0.0-test',
+      isControlAllowed: () => false,
+      mutatingMethods: new Set(),
+      handlers: {
+        list_tools: () => ({
+          tools: [{ name: 'demo_tool', description: 'x', inputSchema: { type: 'object' } }],
+          recommendedBridge: '2.5.0',
+        }),
+      },
+    });
+    const res = await resolveCatalog(new ReverseeClient(dir));
+    expect(res.fromApp).toBe(true);
+    expect(res.tools.map((t) => t.name)).toEqual(['demo_tool']);
+    expect(res.recommendedBridge).toBe('2.5.0');
+  });
+
+  it('falls back to the embedded catalog when the app is down', async () => {
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rev-cat-empty-'));
+    const res = await resolveCatalog(new ReverseeClient(emptyDir));
+    expect(res.fromApp).toBe(false);
+    expect(res.tools).toBe(FALLBACK_CATALOG);
+    expect(res.recommendedBridge).toBeUndefined();
+    fs.rmSync(emptyDir, { recursive: true, force: true });
+  });
+});

--- a/tests/unit/mcp-catalog.test.mjs
+++ b/tests/unit/mcp-catalog.test.mjs
@@ -1,0 +1,53 @@
+// The app-owned MCP tool catalog (electron-free) and its derived mutating set.
+import { describe, it, expect } from 'vitest';
+import {
+  MCP_TOOL_CATALOG,
+  MCP_MUTATING_METHODS,
+  RECOMMENDED_BRIDGE_VERSION,
+} from '../../src/main/mcp/catalog';
+
+describe('MCP tool catalog', () => {
+  it('lists the expected tools', () => {
+    const names = MCP_TOOL_CATALOG.map((t) => t.name).sort();
+    expect(names).toEqual(
+      [
+        'export_diagnostics',
+        'get_config',
+        'get_status',
+        'get_traffic_entry',
+        'list_breakpoints',
+        'list_traffic',
+        'restart_proxy',
+        'start_proxy',
+        'stop_proxy',
+        'update_config',
+        'validate_setup',
+      ].sort()
+    );
+  });
+
+  it('every tool has a description and an object JSON schema', () => {
+    for (const t of MCP_TOOL_CATALOG) {
+      expect(t.description.length, t.name).toBeGreaterThan(10);
+      expect(t.inputSchema.type, t.name).toBe('object');
+    }
+  });
+
+  it('has no duplicate tool names', () => {
+    const names = MCP_TOOL_CATALOG.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('derives the mutating set from the catalog', () => {
+    expect([...MCP_MUTATING_METHODS].sort()).toEqual(
+      ['restart_proxy', 'start_proxy', 'stop_proxy', 'update_config'].sort()
+    );
+    // Read-only tools are not gated.
+    expect(MCP_MUTATING_METHODS.has('get_status')).toBe(false);
+    expect(MCP_MUTATING_METHODS.has('list_traffic')).toBe(false);
+  });
+
+  it('recommends a sensible bridge version', () => {
+    expect(RECOMMENDED_BRIDGE_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});


### PR DESCRIPTION
Implements the compromise we discussed: the **app owns the MCP tool catalog**, so updating the app surfaces new/changed tools through whatever bridge a user already has cached — no `reversee-mcp` republish or reinstall.

## What changed
- **App** serves the catalog (name + description + JSON schema) via a new `list_tools` control method, and **derives the mutating/gated set from it** (single source of truth).
- **Bridge** (`mcp/src/cli.ts`) is now a generic low-level MCP server: at startup it fetches the catalog from the running app and registers those tools dynamically; `tools/call` forwards generically. A **frozen embedded catalog** is the fallback when the app isn't running (so the agent still sees a tool list and gets the friendly "launch Reversee" error).
- **Version advisory** — since npx freezes the cached bridge and never auto-upgrades, the app reports `RECOMMENDED_BRIDGE_VERSION`; when the running bridge is older, `get_status` carries an advisory with the exact *upgrade-to-latest* command (a surgical npx-cache refresh that touches only Reversee's entry — not `clear-npx-cache`). No npm registry polling; the app, which auto-updates itself, carries the knowledge.

## Docs
Root + `mcp/` README and the in-app "Set Up MCP" dialog: bare install (gets latest), "new tools arrive with app updates," and the upgrade-to-latest refresh.

## Tests
+12 unit tests (74 total): catalog consistency + derived mutating set; `isOlder`/`versionAdvisory` logic; `resolveCatalog` against the real control server including the offline fallback. Verified live end-to-end: bridge fetches the live catalog (11 tools), `get_status` advisory, offline fallback, and `update_config` patch round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)