### PR TITLE
MCP stdio e2e + testing docs (TESTING.md, CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# Reversee — guide for AI agents
+
+Reverse-proxy web debugger. Electron 42 + React 19 + TypeScript, built with electron-vite. The proxy runs in a `utilityProcess`; an MCP server (`mcp/`) lets agents drive the app.
+
+## Commands
+
+```sh
+npm install            # installs the root + mcp workspace
+npm start              # run the app (electron-vite dev, HMR)
+npm test               # Vitest: unit + integration + MCP end-to-end
+npm run typecheck      # tsc for app and mcp
+npm run lint           # eslint
+npm run build          # build app into out/
+npx playwright test    # app end-to-end (needs npm run build first)
+npm run build:mcp      # build the reversee-mcp bridge
+```
+
+Always run `npm run lint` and `npm run typecheck` before committing; both gate CI.
+
+## Testing — see [TESTING.md](TESTING.md)
+
+Four layers: unit/integration + MCP e2e (Vitest, `tests/unit/`), app e2e (Playwright, `tests/e2e/`), packaged smoke (release-only, `tests/smoke/`). All but the packaged smoke run on every PR. **Read TESTING.md before adding or changing tests** — it says which layer a change belongs in and how the layers map to CI jobs.
+
+## Layout
+
+- `src/main/` — Electron main: windows, menu, settings (electron-store), proxy host, certs, updater, `mcp/` (control socket + handlers + tool catalog).
+- `src/preload/` — the only renderer bridge; typed `RevAPI`, allowlisted IPC channels.
+- `src/renderer/` — React UI (Zustand stores, Tailwind, Radix).
+- `src/proxy/` — the proxy core (`core/`, plain Node, **no Electron imports** — enforced by ESLint so it stays headless-testable) + the `utilityProcess` worker.
+- `src/shared/` — cross-process types, IPC contracts, settings schema.
+- `mcp/` — the `reversee-mcp` npm package (stdio MCP bridge). The **app owns the MCP tool catalog** (`src/main/mcp/catalog.ts`); the bridge fetches it at runtime, so new tools ship with app updates, not bridge republishes.
+
+## Conventions
+
+- Releases are tag-driven: see [RELEASING.md](RELEASING.md). Don't hand-publish.
+- macOS builds are signed + notarized in CI; never commit secrets or certs.
+- Keep the proxy core Electron-free. Keep new MCP tools defined in the catalog (single source of truth for the bridge and the gated-mutation set).

--- a/README.md
+++ b/README.md
@@ -108,14 +108,16 @@ Requirements: Node 22+.
 ```sh
 npm install
 npm start            # run the app (electron-vite dev, HMR)
-npm test             # unit tests (vitest)
+npm test             # unit + integration + MCP e2e (vitest)
 npm run typecheck    # tsc
 npm run lint         # eslint
-npm run build && npx playwright test   # end-to-end tests
+npm run build && npx playwright test   # app end-to-end tests
 npm run dist         # build installers for this platform
 ```
 
 Layout: `src/main` (Electron main process), `src/preload` (the typed renderer bridge), `src/renderer` (React UI), `src/proxy` (the proxy core — plain Node, runs in a utilityProcess), `src/shared` (types, IPC contracts, settings schema), `mcp/` (the `reversee-mcp` npm package).
+
+Testing is documented in [TESTING.md](TESTING.md) (the four layers and how they map to CI); [CLAUDE.md](CLAUDE.md) orients AI agents; releases in [RELEASING.md](RELEASING.md).
 
 Releases: push a `v*` tag; CI builds, signs, notarizes, verifies, and publishes macOS/Windows/Linux artifacts, then updates Homebrew. See [RELEASING.md](RELEASING.md).
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,48 @@
+# Testing
+
+Reversee has four test layers. All of them except the packaged smoke test run on every PR.
+
+| Layer | Tool | Location | Run locally | Runs in CI |
+| --- | --- | --- | --- | --- |
+| Unit & integration | Vitest | `tests/unit/*.test.mjs` | `npm test` | `checks` job (every push/PR) |
+| App end-to-end | Playwright (Electron) | `tests/e2e/*.spec.ts` | `npm run build && npx playwright test` | `e2e` (macOS) + `e2e-windows` |
+| MCP end-to-end | Vitest (spawns the bridge) | `tests/unit/mcp-stdio.test.mjs` | `npm test` | `checks` job |
+| Packaged smoke | Playwright | `tests/smoke/packaged.spec.ts` | (see below) | **Release only** (tag-triggered) |
+
+`npm test` runs Vitest, which includes both the unit/integration suite and the MCP end-to-end (the latter builds and spawns the real bridge in `beforeAll`). `npm run lint` and `npm run typecheck` round out the `checks` job.
+
+## What each layer covers
+
+### Unit & integration (`tests/unit/`)
+- **Proxy core** (`proxy.core`, `interceptor`, `curl`, `breakpoints`) — the request-forwarding logic, run headlessly against real `http`/`https` fixture servers (no Electron). This is the safety net the whole refactor was built on.
+- **Traffic store** (`traffic-store`) — ring-buffer cap, eviction, body truncation.
+- **MCP** — `control-server` (token handshake, gating, permissions), `mcp-catalog` (the app-owned tool catalog + derived mutating set), `mcp-bridge` (`resolveCatalog` against the real control server incl. offline fallback, version-advisory logic), `mcp-client` (the bridge's socket client against the real server).
+
+### App end-to-end (`tests/e2e/`)
+Playwright drives the built app (`out/`) through real user flows: launch + sandbox assertions, configure/start/proxy/inspect, request & response interceptors, breakpoint hold→edit→resume, invalid-port handling, settings persistence across relaunch, HTTPS listening, and EADDRINUSE surfacing. Needs `npm run build` first.
+
+### MCP end-to-end (`tests/unit/mcp-stdio.test.mjs`)
+Spawns the **real built `reversee-mcp` bridge** and speaks MCP JSON-RPC over stdio against the real control server — the exact path Claude Code / Cursor use. Verifies the bridge advertises the **app's** catalog (including a tool the bridge never shipped with — proving the dynamic catalog), forwards calls, carries the version advisory, and falls back gracefully when the app is down.
+
+### Packaged smoke (`tests/smoke/packaged.spec.ts`)
+Drives the **final signed, notarized app bundle** (not the dev build). It runs only in the release pipeline (`release.yml` → `verify-mac`), after the artifact is downloaded from the draft GitHub release and Gatekeeper-checked, because it needs the packaged binary. To run it by hand against a built app:
+
+```sh
+REVERSEE_APP_BIN="/path/to/Reversee.app/Contents/MacOS/Reversee" \
+  npx playwright test -c playwright.smoke.config.ts
+```
+
+## Quick commands
+
+```sh
+npm test                              # unit + integration + MCP e2e (Vitest)
+npm run typecheck                     # tsc (app + mcp)
+npm run lint                          # eslint
+npm run build && npx playwright test  # app end-to-end
+```
+
+## Adding tests
+
+- **Proxy/core logic** → a Vitest file in `tests/unit/`; reuse the fixtures in `tests/unit/helpers.mjs`.
+- **A new MCP tool** → add it to `src/main/mcp/catalog.ts` and a handler in `src/main/mcp/handlers.ts`; update the catalog assertion in `tests/unit/mcp-catalog.test.mjs`. The bridge needs no change (it serves whatever the app advertises).
+- **A new user flow** → a Playwright spec in `tests/e2e/`; reuse `tests/e2e/fixtures/launch.ts`.

--- a/tests/unit/mcp-stdio.test.mjs
+++ b/tests/unit/mcp-stdio.test.mjs
@@ -1,0 +1,120 @@
+// End-to-end test of the reversee-mcp bridge as a real spawned process:
+// drives the built bridge over MCP stdio (JSON-RPC) against the real control
+// server, exercising the full path an MCP client uses.
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { execSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startControlServer } from '../../src/main/mcp/control-server';
+
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const bridgeEntry = path.join(repoRoot, 'mcp', 'dist', 'cli.js');
+
+beforeAll(() => {
+  // The e2e drives the built bridge binary, so ensure it is current.
+  execSync('npm run build -w reversee-mcp', { cwd: repoRoot, stdio: 'ignore' });
+}, 120_000);
+
+/** Spawns the bridge and speaks newline-delimited JSON-RPC over stdio. */
+function spawnBridge(userDataDir) {
+  const proc = spawn(process.execPath, [bridgeEntry], {
+    env: { ...process.env, REVERSEE_USER_DATA: userDataDir },
+    stdio: ['pipe', 'pipe', 'inherit'],
+  });
+  const pending = new Map();
+  let buffer = '';
+  proc.stdout.on('data', (chunk) => {
+    buffer += chunk.toString();
+    let nl;
+    while ((nl = buffer.indexOf('\n')) >= 0) {
+      const line = buffer.slice(0, nl);
+      buffer = buffer.slice(nl + 1);
+      if (!line.trim()) continue;
+      const msg = JSON.parse(line);
+      if (msg.id !== undefined && pending.has(msg.id)) {
+        pending.get(msg.id)(msg);
+        pending.delete(msg.id);
+      }
+    }
+  });
+  const rpc = (id, method, params) =>
+    new Promise((resolve) => {
+      pending.set(id, resolve);
+      proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    });
+  return { proc, rpc, kill: () => proc.kill() };
+}
+
+let bridge;
+let server;
+let dir;
+
+afterEach(async () => {
+  bridge?.kill();
+  await server?.close();
+  if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  bridge = undefined;
+  server = undefined;
+  dir = undefined;
+});
+
+async function init(b) {
+  await b.rpc(1, 'initialize', {
+    protocolVersion: '2025-06-18',
+    capabilities: {},
+    clientInfo: { name: 'test', version: '1' },
+  });
+  b.proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+}
+
+describe('reversee-mcp bridge over stdio', () => {
+  it('advertises the app catalog and forwards a call when the app is up', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rev-stdio-'));
+    server = await startControlServer({
+      dir,
+      appVersion: '9.9.9-test',
+      isControlAllowed: () => false,
+      mutatingMethods: new Set(),
+      handlers: {
+        list_tools: () => ({
+          tools: [
+            { name: 'get_status', description: 'status', inputSchema: { type: 'object' } },
+            { name: 'demo_new_tool', description: 'a tool the bridge never shipped with', inputSchema: { type: 'object' } },
+          ],
+          recommendedBridge: '2.0.0',
+        }),
+        get_status: () => ({ running: false, appVersion: '9.9.9-test' }),
+      },
+    });
+
+    bridge = spawnBridge(dir);
+    await init(bridge);
+
+    const list = await bridge.rpc(2, 'tools/list');
+    const names = list.result.tools.map((t) => t.name);
+    // A tool defined only by the app is exposed through the unchanged bridge.
+    expect(names).toContain('demo_new_tool');
+    expect(names).toContain('get_status');
+
+    const call = await bridge.rpc(3, 'tools/call', { name: 'get_status', arguments: {} });
+    const status = JSON.parse(call.result.content[0].text);
+    expect(status.appVersion).toBe('9.9.9-test');
+    expect(status.bridge.upToDate).toBe(true); // bridge 2.0.0 == recommended
+  });
+
+  it('serves the fallback catalog and errors gracefully when the app is down', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rev-stdio-down-'));
+    bridge = spawnBridge(dir);
+    await init(bridge);
+
+    const list = await bridge.rpc(2, 'tools/list');
+    // Fallback catalog is the full known set.
+    expect(list.result.tools.length).toBeGreaterThanOrEqual(11);
+
+    const call = await bridge.rpc(3, 'tools/call', { name: 'get_status', arguments: {} });
+    expect(call.result.isError).toBe(true);
+    expect(call.result.content[0].text).toMatch(/not running/i);
+  });
+});


### PR DESCRIPTION
Answers and closes the gaps from the testing review.

## New test — closes the MCP e2e gap
`tests/unit/mcp-stdio.test.mjs` spawns the **real built `reversee-mcp` bridge** and drives it via MCP JSON-RPC over stdio against the real control server — the exact path Claude Code / Cursor use. It asserts:
- the bridge advertises the **app's** catalog, including a tool the bridge never shipped with (proves the dynamic catalog end-to-end),
- `tools/call` forwards and `get_status` carries the version advisory,
- graceful fallback (embedded catalog + "not running" error) when the app is down.

Runs in the `checks` job via `npm test` (builds the bridge in `beforeAll`). 76 unit tests total.

## Docs — easy to find for humans and LLMs
- **TESTING.md** — the four layers (unit/integration, app e2e, MCP e2e, packaged smoke), what each covers, how to run each, and how they map to CI jobs. Notes that everything except the packaged smoke runs on every PR (smoke is release-only because it needs the signed artifact).
- **CLAUDE.md** — AI-agent orientation: commands, layout, conventions, and a pointer to TESTING.md.
- README links both (and RELEASING.md).

## Coverage summary
- MCP catalog work: unit (`mcp-catalog`, `mcp-bridge`) **and** now e2e (`mcp-stdio`).
- All unit/integration + MCP e2e run on PR CI (`checks`); app e2e runs on macOS + Windows; packaged smoke runs on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
