### PR TITLE
MCP: app emits the bridge-upgrade advisory (reaches old bridges)

### DIFF
--- a/mcp/src/catalog.ts
+++ b/mcp/src/catalog.ts
@@ -65,32 +65,3 @@ export async function resolveCatalog(client: ReverseeClient): Promise<ResolvedCa
   }
   return { tools: FALLBACK_CATALOG, fromApp: false };
 }
-
-/** Numeric semver-ish compare of the release core (ignores pre-release tags). */
-export function isOlder(a: string, b: string): boolean {
-  const core = (v: string) => v.split('-')[0].split('.').map((n) => parseInt(n, 10) || 0);
-  const [a0 = 0, a1 = 0, a2 = 0] = core(a);
-  const [b0 = 0, b1 = 0, b2 = 0] = core(b);
-  if (a0 !== b0) return a0 < b0;
-  if (a1 !== b1) return a1 < b1;
-  return a2 < b2;
-}
-
-/** Advisory appended to get_status when the bridge is older than recommended. */
-export function versionAdvisory(
-  bridgeVersion: string,
-  recommendedBridge: string | undefined
-): { upToDate: boolean; version: string; recommended?: string; note?: string } {
-  if (recommendedBridge && isOlder(bridgeVersion, recommendedBridge)) {
-    return {
-      upToDate: false,
-      version: bridgeVersion,
-      recommended: recommendedBridge,
-      note:
-        `A newer reversee-mcp (>= ${recommendedBridge}) is available; you are on ${bridgeVersion}. ` +
-        'Upgrade to latest by clearing the cached copy, then restart your MCP client:\n' +
-        '  for d in ~/.npm/_npx/*/; do [ -e "$d/node_modules/reversee-mcp" ] && rm -rf "$d"; done',
-    };
-  }
-  return { upToDate: true, version: bridgeVersion };
-}

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -13,11 +13,13 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { ReverseeClient } from './client.js';
-import { resolveCatalog, versionAdvisory } from './catalog.js';
+import { resolveCatalog } from './catalog.js';
 
 const BRIDGE_VERSION: string = createRequire(import.meta.url)('../package.json').version;
 
-const client = new ReverseeClient();
+// The version is reported in the handshake; the app emits any upgrade advisory
+// (in get_status) so the signal reaches even older bridges.
+const client = new ReverseeClient(undefined, BRIDGE_VERSION);
 
 // Snapshot the catalog at startup: if the app is up we advertise its tools, if
 // not we advertise the frozen fallback. (A running app launched later is picked
@@ -44,15 +46,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     // its arguments object straight through as the method params.
     const params = name === 'update_config' ? (args?.['patch'] ?? {}) : args;
     const result = await client.call(name, params);
-
-    // Surface an upgrade hint on get_status when the bridge is behind the
-    // version the running app recommends.
-    const payload =
-      name === 'get_status' && result && typeof result === 'object'
-        ? { ...(result as object), bridge: versionAdvisory(BRIDGE_VERSION, catalog.recommendedBridge) }
-        : result;
-
-    return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] };
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
   } catch (error) {
     return { content: [{ type: 'text', text: (error as Error).message }], isError: true };
   }

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -53,7 +53,11 @@ export function socketPathFor(dir: string): string {
 }
 
 export class ReverseeClient {
-  constructor(private dir: string = defaultUserDataDir()) {}
+  constructor(
+    private dir: string = defaultUserDataDir(),
+    /** Reported in the handshake so the app can advise on bridge upgrades. */
+    private bridgeVersion?: string
+  ) {}
 
   async call(method: string, params?: unknown): Promise<unknown> {
     let token: string;
@@ -81,7 +85,7 @@ export class ReverseeClient {
       });
 
       socket.once('connect', () => {
-        socket.write(JSON.stringify({ token }) + '\n');
+        socket.write(JSON.stringify({ token, bridgeVersion: this.bridgeVersion }) + '\n');
       });
 
       socket.on('data', (chunk) => {

--- a/src/main/mcp/catalog.ts
+++ b/src/main/mcp/catalog.ts
@@ -18,11 +18,54 @@ export interface McpToolDef {
 const noInput = { type: 'object', properties: {}, additionalProperties: false };
 
 /**
- * Bumped when we ship a bridge with capabilities the app relies on. The bridge
- * compares its own version against this and advises the user to upgrade if it
- * is older. No npm registry calls are involved.
+ * The bridge version the app wants users on. 2.1.0 is the first *generic*
+ * bridge (it serves the app-owned catalog); the original 2.0.0 bridge had a
+ * hardcoded tool list and cannot receive new tools, so we actively pull users
+ * onto >= 2.1.0. The app reports its own bridge version in the handshake and
+ * the app emits the advisory below — so even the old 2.0.0 bridge (which has
+ * no advisory code of its own but passes get_status through verbatim) surfaces
+ * it. No npm registry calls are involved.
  */
-export const RECOMMENDED_BRIDGE_VERSION = '2.0.0';
+export const RECOMMENDED_BRIDGE_VERSION = '2.1.0';
+
+/** Numeric semver-ish compare of the release core (ignores pre-release tags). */
+export function isOlderVersion(a: string, b: string): boolean {
+  const core = (v: string) => v.split('-')[0].split('.').map((n) => parseInt(n, 10) || 0);
+  const [a0 = 0, a1 = 0, a2 = 0] = core(a);
+  const [b0 = 0, b1 = 0, b2 = 0] = core(b);
+  if (a0 !== b0) return a0 < b0;
+  if (a1 !== b1) return a1 < b1;
+  return a2 < b2;
+}
+
+export interface BridgeAdvisory {
+  upToDate: boolean;
+  recommended: string;
+  reportedVersion?: string;
+  note?: string;
+}
+
+/**
+ * Advisory included in get_status. A missing bridgeVersion means an old bridge
+ * (pre-2.1.0 didn't report one) — treat it as outdated so those users get
+ * pulled forward.
+ */
+export function buildBridgeAdvisory(bridgeVersion: string | undefined): BridgeAdvisory {
+  const outdated = !bridgeVersion || isOlderVersion(bridgeVersion, RECOMMENDED_BRIDGE_VERSION);
+  if (!outdated) {
+    return { upToDate: true, recommended: RECOMMENDED_BRIDGE_VERSION, reportedVersion: bridgeVersion };
+  }
+  return {
+    upToDate: false,
+    recommended: RECOMMENDED_BRIDGE_VERSION,
+    reportedVersion: bridgeVersion,
+    note:
+      `Your reversee-mcp bridge (${bridgeVersion ?? 'pre-2.1.0'}) is older than the recommended ` +
+      `${RECOMMENDED_BRIDGE_VERSION}. The newer bridge receives tools added in app updates automatically. ` +
+      'Upgrade to latest, then restart your MCP client:\n' +
+      '  for d in ~/.npm/_npx/*/; do [ -e "$d/node_modules/reversee-mcp" ] && rm -rf "$d"; done',
+  };
+}
 
 export const MCP_TOOL_CATALOG: McpToolDef[] = [
   {

--- a/src/main/mcp/control-server.ts
+++ b/src/main/mcp/control-server.ts
@@ -23,7 +23,16 @@ export interface ControlRequest {
   params?: unknown;
 }
 
-export type ControlHandler = (params: unknown) => Promise<unknown> | unknown;
+/** Per-connection context derived from the handshake. */
+export interface ControlContext {
+  /** Bridge version reported in the handshake; undefined for pre-2.1.0 bridges. */
+  bridgeVersion?: string;
+}
+
+export type ControlHandler = (
+  params: unknown,
+  ctx: ControlContext
+) => Promise<unknown> | unknown;
 
 export interface ControlServerOptions {
   /** Directory for the socket and token files (the app passes userData). */
@@ -79,6 +88,7 @@ export function startControlServer(options: ControlServerOptions): Promise<Contr
   const server = net.createServer((socket) => {
     let authenticated = false;
     let buffer = '';
+    const ctx: ControlContext = {};
 
     const send = (message: unknown): void => {
       socket.write(JSON.stringify(message) + '\n');
@@ -109,6 +119,7 @@ export function startControlServer(options: ControlServerOptions): Promise<Contr
       if (!authenticated) {
         if (tokensMatch(message['token'], token)) {
           authenticated = true;
+          if (typeof message['bridgeVersion'] === 'string') ctx.bridgeVersion = message['bridgeVersion'];
           send({ ok: true, server: 'reversee', protocol: PROTOCOL_VERSION, version: options.appVersion });
         } else {
           logger.warn('mcp control: handshake with bad token rejected');
@@ -140,7 +151,7 @@ export function startControlServer(options: ControlServerOptions): Promise<Contr
         return;
       }
       try {
-        const result = await handler(params);
+        const result = await handler(params, ctx);
         send({ id, result: result ?? null });
       } catch (error) {
         send({ id, error: { code: 'handler-error', message: (error as Error).message } });

--- a/src/main/mcp/handlers.ts
+++ b/src/main/mcp/handlers.ts
@@ -3,7 +3,12 @@
 import { app } from 'electron';
 import { getSettings, setSettings, getRootCertPem } from '../settings';
 import { isValidPort } from '../../shared/settings-schema';
-import { MCP_TOOL_CATALOG, MCP_MUTATING_METHODS, RECOMMENDED_BRIDGE_VERSION } from './catalog';
+import {
+  MCP_TOOL_CATALOG,
+  MCP_MUTATING_METHODS,
+  RECOMMENDED_BRIDGE_VERSION,
+  buildBridgeAdvisory,
+} from './catalog';
 import type { ControlHandler } from './control-server';
 import type { ProxyHost } from '../proxy-host';
 import type { TrafficStore } from '../traffic-store';
@@ -47,9 +52,10 @@ export function createMcpHandlers(ctx: McpHandlerContext): Record<string, Contro
       recommendedBridge: RECOMMENDED_BRIDGE_VERSION,
     }),
 
-    get_status: () => {
+    get_status: (_params, conn) => {
       const settings = getSettings();
       return {
+        bridge: buildBridgeAdvisory(conn.bridgeVersion),
         appVersion: app.getVersion(),
         running: ctx.proxyHost.isRunning,
         listenProtocol: settings.listenProtocol,

--- a/tests/unit/control-server.test.mjs
+++ b/tests/unit/control-server.test.mjs
@@ -41,9 +41,9 @@ function connect() {
   });
 }
 
-async function authedClient() {
+async function authedClient(bridgeVersion) {
   const client = await connect();
-  client.send({ token: fs.readFileSync(tokenPathFor(dir), 'utf8') });
+  client.send({ token: fs.readFileSync(tokenPathFor(dir), 'utf8'), bridgeVersion });
   const hello = await client.next();
   expect(hello.ok).toBe(true);
   return client;
@@ -61,6 +61,7 @@ beforeEach(async () => {
       get_status: () => ({ running: false }),
       start_proxy: () => ({ started: true }),
       update_config: (params) => ({ updated: params }),
+      echo_ctx: (_params, ctx) => ({ bridgeVersion: ctx.bridgeVersion ?? null }),
       boom: () => {
         throw new Error('handler exploded');
       },
@@ -105,6 +106,20 @@ describe('control server', () => {
     client.send({ id: 3, method: 'update_config', params: { dest: 'x' } });
     const reply = await client.next();
     expect(reply.result).toEqual({ updated: { dest: 'x' } });
+    client.socket.destroy();
+  });
+
+  it('threads the handshake bridgeVersion into the handler context', async () => {
+    const client = await authedClient('2.1.0');
+    client.send({ id: 7, method: 'echo_ctx' });
+    expect((await client.next()).result).toEqual({ bridgeVersion: '2.1.0' });
+    client.socket.destroy();
+  });
+
+  it('leaves bridgeVersion undefined for an old bridge that does not report it', async () => {
+    const client = await authedClient(undefined);
+    client.send({ id: 8, method: 'echo_ctx' });
+    expect((await client.next()).result).toEqual({ bridgeVersion: null });
     client.socket.destroy();
   });
 

--- a/tests/unit/mcp-bridge.test.mjs
+++ b/tests/unit/mcp-bridge.test.mjs
@@ -6,46 +6,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { startControlServer } from '../../src/main/mcp/control-server';
 import { ReverseeClient } from '../../mcp/src/client';
-import {
-  resolveCatalog,
-  versionAdvisory,
-  isOlder,
-  FALLBACK_CATALOG,
-} from '../../mcp/src/catalog';
-
-describe('isOlder', () => {
-  it('compares release cores numerically', () => {
-    expect(isOlder('2.0.0', '2.1.0')).toBe(true);
-    expect(isOlder('2.0.0', '2.0.1')).toBe(true);
-    expect(isOlder('1.9.9', '2.0.0')).toBe(true);
-    expect(isOlder('2.0.0', '2.0.0')).toBe(false);
-    expect(isOlder('2.1.0', '2.0.0')).toBe(false);
-    expect(isOlder('10.0.0', '9.0.0')).toBe(false); // numeric, not lexical
-  });
-
-  it('ignores pre-release suffixes', () => {
-    expect(isOlder('2.0.0-beta.1', '2.0.0')).toBe(false);
-  });
-});
-
-describe('versionAdvisory', () => {
-  it('flags an out-of-date bridge with an upgrade note', () => {
-    const a = versionAdvisory('2.0.0', '2.1.0');
-    expect(a.upToDate).toBe(false);
-    expect(a.recommended).toBe('2.1.0');
-    expect(a.note).toMatch(/reversee-mcp/);
-    expect(a.note).toMatch(/_npx/); // contains the surgical refresh command
-  });
-
-  it('reports up to date when current or ahead', () => {
-    expect(versionAdvisory('2.1.0', '2.1.0').upToDate).toBe(true);
-    expect(versionAdvisory('2.2.0', '2.1.0').upToDate).toBe(true);
-  });
-
-  it('reports up to date when the app gives no recommendation (offline)', () => {
-    expect(versionAdvisory('2.0.0', undefined).upToDate).toBe(true);
-  });
-});
+import { resolveCatalog, FALLBACK_CATALOG } from '../../mcp/src/catalog';
 
 describe('resolveCatalog', () => {
   let dir;

--- a/tests/unit/mcp-catalog.test.mjs
+++ b/tests/unit/mcp-catalog.test.mjs
@@ -4,6 +4,8 @@ import {
   MCP_TOOL_CATALOG,
   MCP_MUTATING_METHODS,
   RECOMMENDED_BRIDGE_VERSION,
+  isOlderVersion,
+  buildBridgeAdvisory,
 } from '../../src/main/mcp/catalog';
 
 describe('MCP tool catalog', () => {
@@ -49,5 +51,38 @@ describe('MCP tool catalog', () => {
 
   it('recommends a sensible bridge version', () => {
     expect(RECOMMENDED_BRIDGE_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe('isOlderVersion', () => {
+  it('compares release cores numerically, ignoring pre-release tags', () => {
+    expect(isOlderVersion('2.0.0', '2.1.0')).toBe(true);
+    expect(isOlderVersion('1.9.9', '2.0.0')).toBe(true);
+    expect(isOlderVersion('2.1.0', '2.1.0')).toBe(false);
+    expect(isOlderVersion('2.2.0', '2.1.0')).toBe(false);
+    expect(isOlderVersion('10.0.0', '9.0.0')).toBe(false); // numeric, not lexical
+    expect(isOlderVersion('2.1.0-beta.1', '2.1.0')).toBe(false);
+  });
+});
+
+describe('buildBridgeAdvisory', () => {
+  it('treats a missing bridge version (old bridge) as outdated', () => {
+    const a = buildBridgeAdvisory(undefined);
+    expect(a.upToDate).toBe(false);
+    expect(a.note).toMatch(/reversee-mcp/);
+    expect(a.note).toMatch(/_npx/); // surgical upgrade command
+  });
+
+  it('flags a bridge older than recommended', () => {
+    const a = buildBridgeAdvisory('2.0.0');
+    expect(a.upToDate).toBe(false);
+    expect(a.recommended).toBe(RECOMMENDED_BRIDGE_VERSION);
+    expect(a.reportedVersion).toBe('2.0.0');
+  });
+
+  it('is clean for a current or newer bridge', () => {
+    expect(buildBridgeAdvisory(RECOMMENDED_BRIDGE_VERSION).upToDate).toBe(true);
+    expect(buildBridgeAdvisory('99.0.0').upToDate).toBe(true);
+    expect(buildBridgeAdvisory(RECOMMENDED_BRIDGE_VERSION).note).toBeUndefined();
   });
 });

--- a/tests/unit/mcp-stdio.test.mjs
+++ b/tests/unit/mcp-stdio.test.mjs
@@ -85,7 +85,9 @@ describe('reversee-mcp bridge over stdio', () => {
           ],
           recommendedBridge: '2.0.0',
         }),
-        get_status: () => ({ running: false, appVersion: '9.9.9-test' }),
+        // Echo the handshake-reported bridge version, proving the bridge sends
+        // it (the real app uses this to emit the upgrade advisory).
+        get_status: (_p, ctx) => ({ running: false, appVersion: '9.9.9-test', reportedBridge: ctx.bridgeVersion }),
       },
     });
 
@@ -101,7 +103,7 @@ describe('reversee-mcp bridge over stdio', () => {
     const call = await bridge.rpc(3, 'tools/call', { name: 'get_status', arguments: {} });
     const status = JSON.parse(call.result.content[0].text);
     expect(status.appVersion).toBe('9.9.9-test');
-    expect(status.bridge.upToDate).toBe(true); // bridge 2.0.0 == recommended
+    expect(status.reportedBridge).toMatch(/^\d+\.\d+\.\d+/); // bridge reported its version in the handshake
   });
 
   it('serves the fallback catalog and errors gracefully when the app is down', async () => {


### PR DESCRIPTION
Fixes the forward-compatibility gap: pull existing MCP users onto the new generic bridge.

The advisory I first built lived *inside* the 2.1.0 bridge, so the users we most want to reach — the ones on the original 2.0.0 bridge — would never see it (that bridge has a hardcoded tool list and no advisory code). This moves the signal to where it can reach them.

## Changes
- The bridge **reports its version in the handshake**.
- The **app emits the upgrade advisory** in `get_status`, keyed on that version. A missing version = a pre-2.1.0 bridge → treated as outdated. Because the old 2.0.0 bridge passes `get_status` through verbatim, the advisory reaches those users.
- `RECOMMENDED_BRIDGE_VERSION` = **2.1.0** — the 2.0.0 bridge can't receive tools added in app updates, so we actively pull users onto the generic ≥2.1.0 bridge.
- Advisory logic moves app-side (`catalog.ts`: `isOlderVersion`/`buildBridgeAdvisory`); bridge-side advisory removed; control-server threads the handshake `bridgeVersion` into a per-connection handler context.

## Verified live
- Current bridge (reports 2.1.0) → `upToDate: true`.
- Old bridge (no version) → `upToDate: false` with the surgical upgrade command.

77 unit tests pass (control-server ctx threading, app-side advisory cases, stdio e2e asserting the bridge reports its version through the real handshake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
