### PR TITLE
Headless mode for agents + Connect AI setup CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ This clears only Reversee's cached copy; the next run pulls the latest published
 - It is **read-only by default**. `start_proxy`, `stop_proxy`, `restart_proxy`, and `update_config` are rejected until you check *Proxy Settings → Allow MCP to Control the Proxy* in the app.
 - *Proxy Settings → Enable MCP Integration* turns the socket off entirely.
 
+### Headless mode (for agents)
+
+An agent that only needs the proxy can run Reversee without the UI. The Homebrew cask puts `reversee` on `PATH`:
+
+```sh
+# isolate the agent's instance with its own profile + socket, allow it to control the proxy
+REVERSEE_USER_DATA="$(mktemp -d)" reversee --headless --allow-mcp-control &
+```
+
+Then point the MCP client at the same profile (`REVERSEE_USER_DATA`) and drive it. Flags:
+
+- `--headless` — no window/dock; runs on the MCP socket until killed. Implies MCP enabled.
+- `--allow-mcp-control` — the launch-time equivalent of *Allow MCP to Control the Proxy* (start/stop/configure).
+- `--no-mcp` / `--allow-mcp` — force the socket off / on.
+
+Flags are session overrides and never change your saved settings. Using a separate `REVERSEE_USER_DATA` lets a headless agent instance coexist with your GUI instance (each gets its own control socket). On Linux a display is still required — wrap with `xvfb-run`.
+
 ## Development
 
 Requirements: Node 22+.

--- a/scripts/render-cask.sh
+++ b/scripts/render-cask.sh
@@ -23,6 +23,9 @@ cask "reversee" do
   auto_updates true
 
   app "Reversee.app"
+  # Puts `reversee` on PATH so agents can run it headless:
+  #   reversee --headless --allow-mcp-control
+  binary "#{appdir}/Reversee.app/Contents/MacOS/Reversee", target: "reversee"
 
   zap trash: [
     "~/Library/Application Support/Reversee",

--- a/src/main/cli-args.ts
+++ b/src/main/cli-args.ts
@@ -1,0 +1,25 @@
+// Launch flags, mainly for agents running Reversee without the UI.
+//
+//   reversee --headless --allow-mcp-control
+//
+// Flags are session overrides: they do not change the user's saved settings.
+
+export interface CliFlags {
+  /** Run with no window/dock; the app lives on the MCP control socket until killed. */
+  headless: boolean;
+  /** Launch-time equivalent of "Allow MCP to Control the Proxy" (start/stop/config). */
+  allowMcpControl: boolean;
+  /** Explicit MCP socket override; undefined = use the saved setting. Headless defaults to on. */
+  mcp?: boolean;
+}
+
+export function parseCliFlags(argv: readonly string[]): CliFlags {
+  const has = (flag: string): boolean => argv.includes(flag);
+  const headless = has('--headless');
+  return {
+    headless,
+    allowMcpControl: has('--allow-mcp-control'),
+    // --no-mcp wins; then --allow-mcp; otherwise headless implies on, GUI uses the saved setting.
+    mcp: has('--no-mcp') ? false : has('--allow-mcp') || headless ? true : undefined,
+  };
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,11 +18,14 @@ import { createMenu } from './menu';
 import { setupUpdater } from './updater';
 import { createMcpHandlers, MCP_MUTATING_METHODS } from './mcp/handlers';
 import { startControlServer, type ControlServer } from './mcp/control-server';
+import { parseCliFlags } from './cli-args';
 import iconAsset from '../../resources/icon.png?asset';
 
 log.transports.file.level = 'info';
 log.transports.console.level = 'info';
 log.info('main process start');
+
+const flags = parseCliFlags(process.argv);
 
 // Test isolation: e2e runs point this at a temp dir so settings, certs, and
 // window state never touch (or depend on) the real profile.
@@ -116,12 +119,12 @@ async function syncControlServer(): Promise<void> {
   if (controlServerBusy) return;
   controlServerBusy = true;
   try {
-    const enabled = getSettings().mcpEnabled;
+    const enabled = flags.mcp ?? getSettings().mcpEnabled;
     if (enabled && !controlServer) {
       controlServer = await startControlServer({
         dir: app.getPath('userData'),
         appVersion: app.getVersion(),
-        isControlAllowed: () => getSettings().mcpAllowControl,
+        isControlAllowed: () => flags.allowMcpControl || getSettings().mcpAllowControl,
         mutatingMethods: MCP_MUTATING_METHODS,
         handlers: createMcpHandlers({
           proxyHost,
@@ -155,12 +158,31 @@ if (!gotLock) {
   });
 
   app.whenReady().then(() => {
-    setupUpdater();
     const { root, leaf } = ensureCertificates();
     leafCert = leaf;
     registerIpc();
     void syncControlServer();
     onSettingsChanged(() => void syncControlServer());
+
+    // Headless (agent) mode: no window, dock, menu, or auto-update — just the
+    // proxy and the MCP control socket. Runs until killed.
+    if (flags.headless) {
+      app.dock?.hide();
+      log.info(
+        `Reversee running headless — MCP ${flags.mcp === false ? 'disabled' : 'enabled'}, ` +
+          `control ${flags.allowMcpControl ? 'ALLOWED' : 'read-only'}.`
+      );
+      const shutdown = (): void => {
+        proxyHost.kill();
+        void controlServer?.close();
+        app.quit();
+      };
+      process.on('SIGINT', shutdown);
+      process.on('SIGTERM', shutdown);
+      return;
+    }
+
+    setupUpdater();
     win = createMainWindow();
 
     app.setAboutPanelOptions({
@@ -187,9 +209,13 @@ if (!gotLock) {
     });
   });
 
-  app.on('window-all-closed', () => {
-    proxyHost.kill();
-    void controlServer?.close();
-    app.quit();
-  });
+  // GUI mode only: headless never opens a window, so it stays alive on the
+  // control socket until it receives a termination signal.
+  if (!flags.headless) {
+    app.on('window-all-closed', () => {
+      proxyHost.kill();
+      void controlServer?.close();
+      app.quit();
+    });
+  }
 }

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -4,8 +4,6 @@
 // the proxy:start payload.
 import {
   app,
-  clipboard,
-  dialog,
   Menu,
   shell,
   type BrowserWindow,
@@ -17,7 +15,6 @@ import { certificateTrustDialog, exportRootCert } from './certs/certs';
 import { checkForUpdatesInteractive } from './updater';
 
 const HOMEPAGE = 'https://github.com/galusben/reversee';
-const MCP_SETUP_COMMAND = 'claude mcp add reversee -- npx -y reversee-mcp';
 
 export function createMenu(
   win: BrowserWindow,
@@ -156,20 +153,8 @@ export function createMenu(
           click: () => void checkForUpdatesInteractive(win),
         },
         {
-          label: 'Set Up MCP (Claude Code)…',
-          click: () => {
-            clipboard.writeText(MCP_SETUP_COMMAND);
-            void dialog.showMessageBox(win, {
-              type: 'info',
-              message: 'MCP setup command copied to clipboard',
-              detail:
-                `Run this in your terminal:\n\n${MCP_SETUP_COMMAND}\n\n` +
-                'For Cursor, add reversee with command "npx" and args ["-y", "reversee-mcp"] ' +
-                'to ~/.cursor/mcp.json.\n\n' +
-                'New tools arrive automatically with app updates. To upgrade the MCP ' +
-                'server itself, see "Updating the MCP server" in the README.',
-            });
-          },
+          label: 'Connect an AI Agent (MCP)…',
+          click: () => win.webContents.send(IPC.openConnectAiEvent),
         },
         ...(!isMac
           ? [

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -30,6 +30,7 @@ const api: RevAPI = {
   onBreakpointHit: subscribe(IPC.breakpointHitEvent),
   onBreakpointErrors: subscribe(IPC.breakpointErrorsEvent),
   onOpenBreakpoints: subscribe(IPC.openBreakpointsEvent),
+  onOpenConnectAi: subscribe(IPC.openConnectAiEvent),
   onProxyState: subscribe(IPC.proxyStateEvent),
   onProxyError: subscribe(IPC.proxyErrorEvent),
   onSettingsChanged: subscribe(IPC.settingsChangedEvent),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -9,6 +9,8 @@ import { TrafficTable } from './components/TrafficTable';
 import { DetailPanes } from './components/DetailPanes';
 import { BreakpointsDialog } from './components/BreakpointsDialog';
 import { BreakpointQueue } from './components/BreakpointQueue';
+import { ConnectAiDialog } from './components/ConnectAiDialog';
+import { useUiStore } from './stores/uiStore';
 
 export default function App(): React.JSX.Element {
   const init = useProxyStore((s) => s.init);
@@ -17,11 +19,14 @@ export default function App(): React.JSX.Element {
   const dismissError = useProxyStore((s) => s.dismissError);
   const running = useProxyStore((s) => s.running);
   const port = useProxyStore((s) => s.port);
+  const openConnectAi = useUiStore((s) => s.setConnectAiOpen);
 
   useEffect(() => {
     void init();
     void initBreakpoints();
-  }, [init, initBreakpoints]);
+    // The Help > Set Up MCP menu item opens the same dialog as the button.
+    return window.reversee.onOpenConnectAi(() => openConnectAi(true));
+  }, [init, initBreakpoints, openConnectAi]);
 
   return (
     <div className="flex h-screen flex-col bg-neutral-100">
@@ -29,6 +34,7 @@ export default function App(): React.JSX.Element {
       <InterceptorPanel />
       <BreakpointQueue />
       <BreakpointsDialog />
+      <ConnectAiDialog />
       {error && (
         <div
           role="alert"

--- a/src/renderer/src/components/ConnectAiDialog.tsx
+++ b/src/renderer/src/components/ConnectAiDialog.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Check, Copy, ExternalLink, Sparkles, X } from 'lucide-react';
+import { useUiStore } from '../stores/uiStore';
+
+const CLAUDE_CMD = 'claude mcp add reversee -- npx -y reversee-mcp';
+const CURSOR_JSON = `{
+  "mcpServers": {
+    "reversee": { "command": "npx", "args": ["-y", "reversee-mcp"] }
+  }
+}`;
+const REPO = 'https://github.com/galusben/reversee#mcp-integration-claude-code--cursor';
+
+function CopyBlock({ label, text }: { label: string; text: string }): React.JSX.Element {
+  const [copied, setCopied] = useState(false);
+  const copy = (): void => {
+    void window.reversee.copyToClipboard(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <div>
+      <div className="mb-1 text-xs font-medium text-neutral-500">{label}</div>
+      <div className="flex items-start gap-2">
+        <pre className="grow overflow-x-auto rounded-md bg-neutral-900 p-2.5 font-mono text-xs leading-5 text-neutral-100">
+          {text}
+        </pre>
+        <button
+          type="button"
+          onClick={copy}
+          aria-label={`Copy ${label}`}
+          className="flex shrink-0 items-center gap-1 rounded-md border border-neutral-300 px-2 py-1.5 text-xs text-neutral-600 hover:bg-neutral-50"
+        >
+          {copied ? <Check className="h-3.5 w-3.5 text-emerald-600" aria-hidden /> : <Copy className="h-3.5 w-3.5" aria-hidden />}
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function ConnectAiDialog(): React.JSX.Element {
+  const open = useUiStore((s) => s.connectAiOpen);
+  const setOpen = useUiStore((s) => s.setConnectAiOpen);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/30" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[560px] max-w-[92vw] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-5 shadow-xl">
+          <div className="mb-1 flex items-center justify-between">
+            <Dialog.Title className="flex items-center gap-2 text-base font-semibold">
+              <Sparkles className="h-4 w-4 text-fuchsia-500" aria-hidden />
+              Connect an AI agent
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button type="button" aria-label="Close" className="rounded p-1 hover:bg-neutral-100">
+                <X className="h-4 w-4" aria-hidden />
+              </button>
+            </Dialog.Close>
+          </div>
+          <Dialog.Description className="mb-4 text-sm text-neutral-500">
+            Let Claude Code, Cursor, or any MCP client inspect and control Reversee. Keep this app
+            running, then register the server:
+          </Dialog.Description>
+
+          <div className="space-y-4">
+            <CopyBlock label="Claude Code" text={CLAUDE_CMD} />
+            <CopyBlock label="Cursor — add to ~/.cursor/mcp.json" text={CURSOR_JSON} />
+          </div>
+
+          <div className="mt-4 flex items-center justify-between border-t border-neutral-100 pt-3">
+            <p className="text-xs text-neutral-500">
+              Read-only by default — enable <span className="font-medium">Allow MCP to Control the Proxy</span>{' '}
+              in the Proxy Settings menu to let agents start/stop it.
+            </p>
+            <a
+              href={REPO}
+              target="_blank"
+              rel="noreferrer"
+              className="flex shrink-0 items-center gap-1 text-xs text-blue-600 hover:underline"
+            >
+              Learn more <ExternalLink className="h-3 w-3" aria-hidden />
+            </a>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/renderer/src/components/SettingsBar.tsx
+++ b/src/renderer/src/components/SettingsBar.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { ArrowRight, OctagonPause, Play, Square } from 'lucide-react';
+import { ArrowRight, OctagonPause, Play, Sparkles, Square } from 'lucide-react';
 import { useProxyStore } from '../stores/proxyStore';
 import { useBreakpointStore } from '../stores/breakpointStore';
+import { useUiStore } from '../stores/uiStore';
 import { isValidPort, type AppSettings } from '../../../shared/settings-schema';
 import type { Protocol } from '../../../shared/types';
 
@@ -78,6 +79,7 @@ export function SettingsBar(): React.JSX.Element | null {
   const stop = useProxyStore((s) => s.stop);
   const openBreakpoints = useBreakpointStore((s) => s.setEditorOpen);
   const ruleCount = useBreakpointStore((s) => s.rules.length);
+  const openConnectAi = useUiStore((s) => s.setConnectAiOpen);
 
   const [invalidPorts, setInvalidPorts] = useState({ listen: false, dest: false });
 
@@ -132,6 +134,15 @@ export function SettingsBar(): React.JSX.Element | null {
         onValidity={(valid) => setInvalidPorts((p) => ({ ...p, dest: !valid }))}
       />
       <div className="grow" />
+      <button
+        type="button"
+        onClick={() => openConnectAi(true)}
+        title="Connect an AI agent (MCP)"
+        className="flex items-center gap-1.5 rounded-md bg-gradient-to-r from-indigo-500 to-fuchsia-500 px-2.5 py-1.5 text-sm font-medium text-white shadow-sm transition-opacity hover:opacity-90"
+      >
+        <Sparkles className="h-3.5 w-3.5" aria-hidden />
+        Connect AI
+      </button>
       <button
         type="button"
         onClick={() => openBreakpoints(true)}

--- a/src/renderer/src/stores/uiStore.ts
+++ b/src/renderer/src/stores/uiStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface UiStore {
+  connectAiOpen: boolean;
+  setConnectAiOpen(open: boolean): void;
+}
+
+// Small store so both the "Connect AI" button and the Help menu item open the
+// same setup dialog.
+export const useUiStore = create<UiStore>((set) => ({
+  connectAiOpen: false,
+  setConnectAiOpen: (connectAiOpen) => set({ connectAiOpen }),
+}));

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -32,6 +32,7 @@ export const IPC = {
   breakpointHitEvent: 'breakpoint:hit',
   breakpointErrorsEvent: 'breakpoint:errors',
   openBreakpointsEvent: 'ui:open-breakpoints',
+  openConnectAiEvent: 'ui:open-connect-ai',
 } as const;
 
 export interface ProxyState {
@@ -81,6 +82,7 @@ export interface RevAPI {
   onBreakpointHit(cb: (hit: BreakpointHit) => void): () => void;
   onBreakpointErrors(cb: (errors: BreakpointCompileError[]) => void): () => void;
   onOpenBreakpoints(cb: () => void): () => void;
+  onOpenConnectAi(cb: () => void): () => void;
   onProxyState(cb: (state: ProxyState) => void): () => void;
   onProxyError(cb: (error: ProxyErrorInfo) => void): () => void;
   onSettingsChanged(cb: (settings: AppSettings) => void): () => void;

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -29,6 +29,15 @@ test('launches with a visible window and secure renderer', async () => {
   expect(await page.evaluate(() => typeof (window as never)['process'])).toBe('undefined');
 });
 
+test('Connect AI button opens the MCP setup dialog', async () => {
+  launched = await launchApp();
+  const { page } = launched;
+  await page.getByRole('button', { name: /Connect AI/ }).click();
+  await expect(page.getByText('Connect an AI agent')).toBeVisible();
+  await expect(page.getByText('claude mcp add reversee -- npx -y reversee-mcp')).toBeVisible();
+  await expect(page.getByText(/~\/.cursor\/mcp.json/)).toBeVisible();
+});
+
 test('proxies a request and shows it in the table with details', async () => {
   upstream = await startUpstream((req, res) => {
     res.writeHead(200, { 'content-type': 'application/json' });

--- a/tests/unit/cli-args.test.mjs
+++ b/tests/unit/cli-args.test.mjs
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { parseCliFlags } from '../../src/main/cli-args';
+
+describe('parseCliFlags', () => {
+  it('defaults to GUI mode with no overrides', () => {
+    const f = parseCliFlags(['/path/electron', 'index.js']);
+    expect(f.headless).toBe(false);
+    expect(f.allowMcpControl).toBe(false);
+    expect(f.mcp).toBeUndefined(); // use saved setting
+  });
+
+  it('headless implies MCP enabled', () => {
+    const f = parseCliFlags(['x', '--headless']);
+    expect(f.headless).toBe(true);
+    expect(f.mcp).toBe(true);
+  });
+
+  it('parses the control opt-in', () => {
+    expect(parseCliFlags(['x', '--headless', '--allow-mcp-control']).allowMcpControl).toBe(true);
+    expect(parseCliFlags(['x', '--headless']).allowMcpControl).toBe(false);
+  });
+
+  it('--no-mcp overrides everything, even headless', () => {
+    expect(parseCliFlags(['x', '--headless', '--no-mcp']).mcp).toBe(false);
+    expect(parseCliFlags(['x', '--allow-mcp', '--no-mcp']).mcp).toBe(false);
+  });
+
+  it('--allow-mcp forces the socket on in GUI mode', () => {
+    expect(parseCliFlags(['x', '--allow-mcp']).mcp).toBe(true);
+  });
+});


### PR DESCRIPTION
Two halves of the "let agents use Reversee" story.

## Headless mode (agent-initiated)
`reversee --headless` runs with no window/dock/menu/updater — just the proxy and the MCP control socket, until killed.
- `--allow-mcp-control` — launch-time equivalent of *Allow MCP to Control the Proxy*.
- `--allow-mcp` / `--no-mcp` — force the socket on/off. Flags are session-only (never touch saved settings).
- The cask installs a `reversee` binary on PATH, so an agent can `REVERSEE_USER_DATA=... reversee --headless --allow-mcp-control &` and drive it over MCP — isolated from any GUI instance via its own profile/socket.
- Verified live: launches windowless, agent sets config + starts the proxy over MCP, clean SIGTERM shutdown.

## Connect AI CTA (human-initiated, in the GUI)
A sparkly gradient **Connect AI** button left of Breakpoints opens a polished React modal: Claude Code one-liner + copy, Cursor JSON + copy, read-only-by-default note, learn-more link. The Help menu's MCP item now opens the same dialog (one setup UI), replacing the old native message box.

## Tests
`parseCliFlags` unit tests; e2e for the Connect AI dialog. 82 unit + e2e green; README gains a headless/agent section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
