### PR TITLE
Clarify npx caching is version-dependent (npm 11.2+ auto-updates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,15 @@ The app owns this list — it serves the catalog to the bridge at startup, so **
 
 ### Updating the MCP server
 
-`npx` caches the server on first run and does not auto-upgrade it. You rarely need to update — new tools arrive via app updates — but if the app reports a newer `reversee-mcp` is recommended (in `get_status`), upgrade to latest and restart your MCP client:
+You rarely need to — new tools arrive via app updates (the app owns the catalog). If the app does report a newer `reversee-mcp` is recommended (in `get_status`), restart your MCP client; on **npm 11.2+** that pulls the latest automatically.
+
+On **older npm** (including npm 10.x bundled with Node 22 LTS), `npx` caches the server and won't re-fetch a newer version — [a known npm behavior](https://github.com/npm/cli/pull/8100). Clear Reversee's cached copy once, then restart:
 
 ```sh
 for d in ~/.npm/_npx/*/; do [ -e "$d/node_modules/reversee-mcp" ] && rm -rf "$d"; done
 ```
 
-This clears only Reversee's cached copy; the next run pulls the latest published version.
+This touches only Reversee's `npx` cache; the next run pulls the latest published version.
 
 ### Security model
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -40,7 +40,9 @@ The Reversee app owns this list and serves it to the bridge at startup, so tools
 
 ## Updating
 
-`npx` caches this server and won't auto-upgrade it. If `get_status` reports a newer version is recommended, upgrade to latest and restart your MCP client:
+You rarely need to — new tools arrive via Reversee app updates. If `get_status` reports a newer version is recommended, restart your MCP client; on **npm 11.2+** that fetches the latest.
+
+On **older npm** (e.g. npm 10.x with Node 22 LTS), `npx` reuses the cached copy ([known npm behavior](https://github.com/npm/cli/pull/8100)) — clear it once, then restart:
 
 ```sh
 for d in ~/.npm/_npx/*/; do [ -e "$d/node_modules/reversee-mcp" ] && rm -rf "$d"; done

--- a/src/main/mcp/catalog.ts
+++ b/src/main/mcp/catalog.ts
@@ -62,7 +62,8 @@ export function buildBridgeAdvisory(bridgeVersion: string | undefined): BridgeAd
     note:
       `Your reversee-mcp bridge (${bridgeVersion ?? 'pre-2.1.0'}) is older than the recommended ` +
       `${RECOMMENDED_BRIDGE_VERSION}. The newer bridge receives tools added in app updates automatically. ` +
-      'Upgrade to latest, then restart your MCP client:\n' +
+      'Restart your MCP client to upgrade — on npm 11.2+ that pulls the latest. On older npm, ' +
+      'clear the cache once first:\n' +
       '  for d in ~/.npm/_npx/*/; do [ -e "$d/node_modules/reversee-mcp" ] && rm -rf "$d"; done',
   };
 }


### PR DESCRIPTION
Follow-up to the npx-cache rabbit hole. Verified against npm sources: npx only freezes the cached version on **npm < 11.2** — [npm/cli #7838](https://github.com/npm/cli/issues/7838). **npm 11.2.0** ([PR #8100](https://github.com/npm/cli/pull/8100), Feb 2025) refreshes ranges/bare names from the registry. So 'npx caches and never updates' was only true for older npm (which still includes npm 10.x bundled with Node 22 LTS).

Reframes the update guidance in README, mcp/README, and the in-app `get_status` advisory: **restart your MCP client** (npm 11.2+ pulls the latest); the cache-clear one-liner is now the older-npm fallback rather than the headline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)