### PR TITLE
ci: pin GitHub Actions to commit SHAs + lock CI token to read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,18 @@ env:
   # heap on macOS runners and OOMs intermittently.
   NODE_OPTIONS: --max-old-space-size=4096
 
+# Least privilege by default: CI only needs to read the repo. Explicit here so
+# the workflow stays read-only even if the repo/org default token grant changes.
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Lint, typecheck, unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: npm
@@ -30,15 +35,15 @@ jobs:
     name: E2E (macOS)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build
       - run: npx playwright test
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: playwright-traces
@@ -51,8 +56,8 @@ jobs:
     # Informational while the suite stabilizes on Windows runners.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: npm
@@ -73,15 +78,15 @@ jobs:
       # secrets are configured.
       CSC_IDENTITY_AUTO_DISCOVERY: 'false'
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build
       - run: npx electron-builder --publish=never
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: reversee-${{ matrix.os }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: npm
@@ -54,8 +54,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       VERSION: ${{ github.ref_name }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: npm
@@ -130,7 +130,7 @@ jobs:
       VERSION: ${{ github.ref_name }}
       HAS_TAP_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN != '' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Update the cask
         if: env.HAS_TAP_TOKEN == 'true'
         env:


### PR DESCRIPTION
## Why

Security review of the Actions config (public repo). Two hardening fixes:

- **Pin actions to commit SHAs** — `checkout`, `setup-node`, `upload-artifact` were on mutable `@vN` tags. A compromised action repo (cf. the `tj-actions/changed-files` incident) could repoint a tag and run attacker code inside the **secret-bearing release job** (Apple signing certs, `CSC_*`, `TAP_GITHUB_TOKEN`). SHA pins close that supply-chain vector. Dependabot still bumps the pins; the version stays readable in the trailing comment.
- **Explicit `permissions: contents: read` in CI** — keeps the job token least-privilege regardless of repo/org default grant changes.

## Changes
- `.github/workflows/ci.yml` — pin all 3 actions; add top-level read-only `permissions`.
- `.github/workflows/release.yml` — pin `checkout` + `setup-node`.

No behavior change; pinned SHAs are the current release tags (v5.0.1 / v5.0.0 / v7.0.1).

## Not in this PR (settings/token changes, tracked separately)
- Branch + `v*` tag rulesets on `main`
- Swap `TAP_GITHUB_TOKEN` to a fine-grained single-repo token
- Tighten `allowed_actions` from `all`; verify fork-PR approval setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)