### PR TITLE
docs: add agent/contributor knowledge base

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# Reversee — guide for AI agents
+
+Reverse-proxy web debugger. **Electron 42 + React 19 + TypeScript**, built with
+electron-vite. It sits between a client and a destination server so you can see,
+intercept, and edit HTTP/HTTPS traffic. The proxy runs in a `utilityProcess`; an
+MCP server (`mcp/`) lets agents drive the running app.
+
+This file is the canonical agent entry point (the vendor-neutral
+[agents.md](https://agents.md) convention). It's a scannable hub — the deep
+knowledge base lives in [`docs/`](docs/README.md).
+
+## Commands
+
+```sh
+npm install            # installs the root + mcp workspace
+npm start              # run the app (electron-vite dev, HMR)
+npm test               # Vitest: unit + integration + MCP end-to-end
+npm run typecheck      # tsc for app and mcp
+npm run lint           # eslint
+npm run build          # build app into out/
+npx playwright test    # app end-to-end (needs npm run build first)
+npm run build:mcp      # build the reversee-mcp bridge
+```
+
+## Where to find what
+
+Full map with entry-point files and "common change → files to touch" recipes:
+**[docs/architecture.md](docs/architecture.md)**.
+
+- `src/main/` — Electron main: lifecycle, windows, menu, settings, proxy host,
+  certs, updater, and `mcp/` (control socket + handlers + tool catalog).
+- `src/preload/` — the only renderer bridge; typed `RevAPI`, allowlisted IPC.
+- `src/renderer/` — React UI (Zustand stores, Tailwind, Radix).
+- `src/proxy/` — the proxy core (`core/`, plain Node, **no Electron imports**) +
+  the `utilityProcess` worker.
+- `src/shared/` — cross-process types, IPC contracts, settings schema.
+- `mcp/` — the `reversee-mcp` npm package (stdio MCP bridge).
+
+## Working agreements
+
+- **Always run `npm run lint` and `npm run typecheck` before committing** — both
+  gate CI.
+- **Keep the proxy core Electron-free** (`src/proxy/core/` is ESLint-enforced so
+  it stays headless-testable — see [ADR 0001](docs/adr/0001-electron-free-proxy-core.md)).
+- **New MCP tools go in the catalog** (`src/main/mcp/catalog.ts`), the single
+  source of truth for the bridge and the gated-mutation set — see
+  [ADR 0002](docs/adr/0002-app-owns-mcp-tool-catalog.md).
+- **Releases are tag-driven** — never hand-publish. See [RELEASING.md](RELEASING.md).
+- Read [TESTING.md](TESTING.md) before adding or changing tests; it says which of
+  the four layers a change belongs in.
+- More: [docs/conventions.md](docs/conventions.md).
+
+## Driving the app at runtime (MCP)
+
+Agents inspect and control the running app over the Model Context Protocol via the
+`reversee-mcp` bridge. Read-only tools (status, config, traffic, breakpoints,
+diagnostics) are always available; mutating tools (start/stop/restart, config
+changes) are **gated** behind "Allow MCP to Control the Proxy" / `--allow-mcp-control`.
+The bridge talks to the app over a token-authenticated local socket — never TCP.
+
+See **[docs/features.md](docs/features.md)** for the full capability catalog and
+[mcp/README.md](mcp/README.md) for bridge setup.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,37 +1,15 @@
-# Reversee — guide for AI agents
+# Reversee — Claude Code notes
 
-Reverse-proxy web debugger. Electron 42 + React 19 + TypeScript, built with electron-vite. The proxy runs in a `utilityProcess`; an MCP server (`mcp/`) lets agents drive the app.
+Agent guidance lives in **[AGENTS.md](AGENTS.md)** (commands, the code map,
+working agreements, and how to drive the app over MCP). Read that first — it is
+the canonical entry point, and the deeper knowledge base is in
+[`docs/`](docs/README.md).
 
-## Commands
+## Claude-specific notes
 
-```sh
-npm install            # installs the root + mcp workspace
-npm start              # run the app (electron-vite dev, HMR)
-npm test               # Vitest: unit + integration + MCP end-to-end
-npm run typecheck      # tsc for app and mcp
-npm run lint           # eslint
-npm run build          # build app into out/
-npx playwright test    # app end-to-end (needs npm run build first)
-npm run build:mcp      # build the reversee-mcp bridge
-```
-
-Always run `npm run lint` and `npm run typecheck` before committing; both gate CI.
-
-## Testing — see [TESTING.md](TESTING.md)
-
-Four layers: unit/integration + MCP e2e (Vitest, `tests/unit/`), app e2e (Playwright, `tests/e2e/`), packaged smoke (release-only, `tests/smoke/`). All but the packaged smoke run on every PR. **Read TESTING.md before adding or changing tests** — it says which layer a change belongs in and how the layers map to CI jobs.
-
-## Layout
-
-- `src/main/` — Electron main: windows, menu, settings (electron-store), proxy host, certs, updater, `mcp/` (control socket + handlers + tool catalog).
-- `src/preload/` — the only renderer bridge; typed `RevAPI`, allowlisted IPC channels.
-- `src/renderer/` — React UI (Zustand stores, Tailwind, Radix).
-- `src/proxy/` — the proxy core (`core/`, plain Node, **no Electron imports** — enforced by ESLint so it stays headless-testable) + the `utilityProcess` worker.
-- `src/shared/` — cross-process types, IPC contracts, settings schema.
-- `mcp/` — the `reversee-mcp` npm package (stdio MCP bridge). The **app owns the MCP tool catalog** (`src/main/mcp/catalog.ts`); the bridge fetches it at runtime, so new tools ship with app updates, not bridge republishes.
-
-## Conventions
-
-- Releases are tag-driven: see [RELEASING.md](RELEASING.md). Don't hand-publish.
-- macOS builds are signed + notarized in CI; never commit secrets or certs.
-- Keep the proxy core Electron-free. Keep new MCP tools defined in the catalog (single source of truth for the bridge and the gated-mutation set).
+- `.claude/settings.local.json` holds a permission allowlist that pre-approves the
+  common commands for this repo (`npm run *`, the `/tmp/reversee-mcp-live` MCP
+  smoke-test setup, and Node module evaluation) so you hit fewer prompts.
+- When driving the running app over MCP, mutating tools require the user to enable
+  "Allow MCP to Control the Proxy" in the app (or `--allow-mcp-control` headless).
+  See [docs/features.md](docs/features.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to Reversee
+
+Thanks for helping improve Reversee. This guide covers setup, the change workflow,
+and where to look when you're stuck. For the deeper picture, read
+[AGENTS.md](AGENTS.md) and the [knowledge base](docs/README.md).
+
+## Setup
+
+Requires Node.js (see `package.json` `engines` / `.nvmrc` if present).
+
+```sh
+npm install      # installs the root + the mcp/ workspace
+npm start        # run the app in dev (electron-vite, HMR)
+```
+
+## Make a change
+
+1. **Branch** off `main`.
+2. Make your change. Use the code map in
+   [docs/architecture.md](docs/architecture.md) to find the right files, including
+   the "common change → files to touch" recipes.
+3. **Add or update tests.** Pick the right layer per [TESTING.md](TESTING.md).
+4. **Run the gates** before committing:
+   ```sh
+   npm run lint
+   npm run typecheck
+   npm test
+   ```
+   App end-to-end tests run with `npm run build` then `npx playwright test`.
+5. **Open a PR** to `main`. CI runs lint, typecheck, unit/integration + MCP e2e, and
+   Playwright e2e (macOS + Windows); they must pass.
+
+## Conventions to know
+
+- Keep the proxy core (`src/proxy/core/`) **Electron-free** — it's ESLint-enforced.
+- Define new MCP tools in `src/main/mcp/catalog.ts` (single source of truth), then
+  implement them in `handlers.ts`.
+- Expose new renderer capabilities through the preload `RevAPI` allowlist, never raw
+  `ipcRenderer`.
+- Never commit secrets or certificates.
+
+Full list: [docs/conventions.md](docs/conventions.md). The rationale behind the big
+decisions: [docs/adr/](docs/adr/README.md).
+
+## Releases
+
+You don't publish by hand — releases are tag-driven. Maintainers cut a `v*` tag and
+a gated pipeline takes over. See [RELEASING.md](RELEASING.md).

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ npm run dist         # build installers for this platform
 
 Layout: `src/main` (Electron main process), `src/preload` (the typed renderer bridge), `src/renderer` (React UI), `src/proxy` (the proxy core — plain Node, runs in a utilityProcess), `src/shared` (types, IPC contracts, settings schema), `mcp/` (the `reversee-mcp` npm package).
 
-Testing is documented in [TESTING.md](TESTING.md) (the four layers and how they map to CI); [CLAUDE.md](CLAUDE.md) orients AI agents; releases in [RELEASING.md](RELEASING.md).
+New here? The [knowledge base](docs/README.md) is the fast way in: a code map ([docs/architecture.md](docs/architecture.md)), the human + agent feature catalog ([docs/features.md](docs/features.md)), conventions, and architecture decisions. See [CONTRIBUTING.md](CONTRIBUTING.md) to make a change and [AGENTS.md](AGENTS.md) for agent guidance.
+
+Testing is documented in [TESTING.md](TESTING.md) (the four layers and how they map to CI); releases in [RELEASING.md](RELEASING.md).
 
 Releases: push a `v*` tag; CI builds, signs, notarizes, verifies, and publishes macOS/Windows/Linux artifacts, then updates Homebrew. See [RELEASING.md](RELEASING.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+# Reversee knowledge base
+
+A place for agents and new contributors to learn the project fast. Start with the
+entry points, then dive into the topic you need.
+
+## Entry points
+
+- **[AGENTS.md](../AGENTS.md)** — the agent entry hub (commands, code map, working
+  agreements, MCP). Read this first.
+- **[../README.md](../README.md)** — user-facing overview: features, install, MCP
+  setup, headless mode.
+
+## In this knowledge base
+
+- **[architecture.md](architecture.md)** — the code map: process model, every
+  source area with its entry-point files, and "common change → files to touch"
+  recipes.
+- **[features.md](features.md)** — what humans can do in the UI and what agents
+  can do over MCP (the 11 tools + the gated-mutation model).
+- **[conventions.md](conventions.md)** — coding/process conventions and the map of
+  related repositories and artifacts.
+- **[adr/](adr/README.md)** — Architecture Decision Records: the key decisions and
+  why, plus the open/deferred ones.
+
+## Reference docs (authoritative, linked not duplicated)
+
+- **[CONTRIBUTING.md](../CONTRIBUTING.md)** — how to set up, branch, and open a PR.
+- **[TESTING.md](../TESTING.md)** — the four test layers and how they map to CI.
+- **[RELEASING.md](../RELEASING.md)** — the tag-driven release pipeline.
+- **[mcp/README.md](../mcp/README.md)** — the `reversee-mcp` bridge: tools + security.
+
+## Machine-readable / web
+
+- **[llms.txt](llms.txt)** — short project summary for LLM crawlers ([llmstxt.org](https://llmstxt.org)).
+- **[index.html](index.html)** — the GitHub Pages landing site
+  (<https://galusben.github.io/reversee/>).

--- a/docs/adr/0001-electron-free-proxy-core.md
+++ b/docs/adr/0001-electron-free-proxy-core.md
@@ -1,0 +1,26 @@
+# 0001 — Electron-free proxy core
+
+Status: accepted
+
+## Context
+
+The reverse-proxy logic (listening, forwarding, decompression, interceptors,
+breakpoints) is the heart of the app and the part most in need of fast, thorough
+testing. Electron is heavy to spin up and couples code to a desktop runtime, which
+makes pure logic slow and awkward to test and impossible to reuse headlessly.
+
+## Decision
+
+Keep `src/proxy/core/` as **plain Node with no Electron imports**, and run it in a
+`utilityProcess` worker (`src/proxy/worker.ts`) that communicates with main over
+typed `parentPort` messages. An **ESLint rule forbids Electron imports** in the
+proxy core so the boundary can't erode.
+
+## Consequences
+
+- The core can be unit/integration-tested without launching Electron (fast CI).
+- The worker is disposable: a wedged interceptor or crash is recovered by killing
+  and respawning the `utilityProcess` (`restart_proxy`), with no state in the worker.
+- New proxy behavior must stay Electron-free; anything needing Electron belongs in
+  `src/main/` and is reached through worker messages
+  ([architecture.md](../architecture.md)).

--- a/docs/adr/0002-app-owns-mcp-tool-catalog.md
+++ b/docs/adr/0002-app-owns-mcp-tool-catalog.md
@@ -1,0 +1,30 @@
+# 0002 — The app owns the MCP tool catalog
+
+Status: accepted
+
+## Context
+
+Agents reach the app through the `reversee-mcp` stdio bridge, distributed on npm and
+typically run via `npx`. If the bridge hardcoded its tool list, every new or changed
+tool would require republishing the bridge *and* every user clearing their npx cache
+and reinstalling — so the app and the agent surface would drift, and shipping a tool
+would be a two-package release.
+
+## Decision
+
+The **app owns the authoritative tool catalog** in
+[`src/main/mcp/catalog.ts`](../../src/main/mcp/catalog.ts). The bridge fetches it at
+startup (the `list_tools` control method) and registers exactly those tools. The
+bridge keeps only a **frozen fallback copy** (`mcp/src/catalog.ts`) for when the app
+is down. The catalog also derives the gated-mutation set (`MCP_MUTATING_METHODS`) and
+carries a bridge-version advisory that nudges users off the pre-2.1.0 bridge (which
+had a hardcoded list).
+
+## Consequences
+
+- Tools added in an app update reach agents automatically — no bridge republish, no
+  npx cache dance.
+- `catalog.ts` is the single source of truth for tool definitions *and* which tools
+  are gated; the module is kept dependency-free so it can be unit-tested headlessly.
+- Adding a tool = catalog entry + `handlers.ts` implementation + a catalog test
+  assertion (see [TESTING.md](../../TESTING.md)).

--- a/docs/adr/0003-gated-mcp-mutations-over-local-socket.md
+++ b/docs/adr/0003-gated-mcp-mutations-over-local-socket.md
@@ -1,0 +1,30 @@
+# 0003 — Gated MCP mutations over a local socket
+
+Status: accepted
+
+## Context
+
+Letting an agent drive a reverse proxy is powerful and dangerous: changing the
+destination, rewriting traffic, or starting/stopping the proxy can redirect or
+expose a user's requests. The bridge runs on the user's machine alongside other
+local software. The transport and authority model must make read-only inspection
+easy while keeping state changes deliberate and local.
+
+## Decision
+
+- The bridge talks to the app over a **local Unix socket / Windows named pipe
+  (mode 0600), never a TCP port**, authenticated with a **per-boot token file**
+  (also 0600). See `src/main/mcp/control-server.ts`.
+- **Read-only tools are always available.** **Mutating tools are gated**: rejected
+  unless the user enables "Allow MCP to Control the Proxy" in the app, or launches
+  headless with `--allow-mcp-control`. The gated set is derived from the catalog
+  (`mutating: true`), so it can't fall out of sync — see
+  [ADR 0002](0002-app-owns-mcp-tool-catalog.md).
+
+## Consequences
+
+- No network listener is exposed; only local processes with the token can connect.
+- Agents can always inspect (status, config, traffic, breakpoints, diagnostics)
+  without a prompt, but changing state requires an explicit human/CI opt-in.
+- New mutating tools must be marked `mutating: true` in the catalog so they're gated
+  by default.

--- a/docs/adr/0004-tag-driven-release-pipeline.md
+++ b/docs/adr/0004-tag-driven-release-pipeline.md
@@ -1,0 +1,33 @@
+# 0004 — Tag-driven, gated release pipeline
+
+Status: accepted
+
+## Context
+
+Reversee ships signed, notarized desktop binaries across macOS, Windows, and Linux,
+plus a Homebrew cask and the `reversee-mcp` npm package. Hand-publishing is
+error-prone and risks releasing artifacts that fail signing/notarization or
+Gatekeeper. Releases need to be reproducible and to refuse to go live until the
+macOS artifacts are verified.
+
+## Decision
+
+Releases are **driven entirely by pushing a `v*` git tag**. The pipeline (see
+[RELEASING.md](../../RELEASING.md) and `.github/workflows/release.yml`) runs in gated
+stages:
+
+1. **build** — multi-platform build; macOS signed + notarized when secrets are present.
+2. **verify-mac** — download the draft artifacts and validate codesign, notarization,
+   and Gatekeeper, then a packaged smoke test.
+3. **promote** — publish the draft as a release (latest, or prerelease for tags with a
+   hyphen like `-beta.1`).
+4. **homebrew** — update the cask in `galusben/homebrew-reversee` (stable releases only).
+
+Nothing is published by hand.
+
+## Consequences
+
+- A release is reproducible from a tag, and nothing reaches users until macOS
+  artifacts are verified.
+- Pre-release tags (`-beta.1`, etc.) publish as prereleases and skip Homebrew.
+- Secrets (signing/notarization, tap token) live only in CI; never in the repo.

--- a/docs/adr/0005-deferred-decisions.md
+++ b/docs/adr/0005-deferred-decisions.md
@@ -1,0 +1,30 @@
+# 0005 — Deferred decisions
+
+Status: open
+
+## Context
+
+Some decisions surfaced during the project's modernization but were deliberately
+**deferred** rather than decided. Recording them keeps the open questions visible so
+they're picked up intentionally instead of rediscovered, and so a contributor doesn't
+assume the current behavior is a settled choice.
+
+## Open questions
+
+- **S3 → GitHub user migration.** The legacy update/download channel used S3; the
+  current pipeline publishes to GitHub Releases (see
+  [ADR 0004](0004-tag-driven-release-pipeline.md) and the "Legacy S3 channel" note in
+  [RELEASING.md](../../RELEASING.md)). How (and whether) to migrate existing users off
+  the S3 channel is undecided.
+- **Code signing breadth.** macOS is signed + notarized in CI; the policy for signing
+  Windows (and whether to invest in it) is not yet settled.
+- **MCP on by default.** Today MCP control is opt-in (mutations gated — see
+  [ADR 0003](0003-gated-mcp-mutations-over-local-socket.md)). Whether the MCP server
+  should be enabled by default, and under what safeguards, is open.
+
+## Consequences
+
+- These are not commitments — treat the current behavior as the status quo, not a
+  decided position.
+- When one is resolved, add a new numbered ADR that decides it and update this file
+  to point at it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,18 @@
+# Architecture Decision Records
+
+An ADR captures one significant decision: its **context**, the **decision**, and the
+**consequences**. They explain *why* the code looks the way it does, so future
+changes don't relitigate settled trade-offs or quietly violate them. Format is
+[MADR](https://adr.github.io/madr/)-lite.
+
+When you make a decision that shapes the architecture, add the next-numbered file
+here and link it from the relevant code area or doc. Don't edit a decided ADR to
+reverse it — add a new one that supersedes it.
+
+## Index
+
+- [0001 — Electron-free proxy core](0001-electron-free-proxy-core.md) · accepted
+- [0002 — The app owns the MCP tool catalog](0002-app-owns-mcp-tool-catalog.md) · accepted
+- [0003 — Gated MCP mutations over a local socket](0003-gated-mcp-mutations-over-local-socket.md) · accepted
+- [0004 — Tag-driven release pipeline](0004-tag-driven-release-pipeline.md) · accepted
+- [0005 — Deferred decisions](0005-deferred-decisions.md) · open

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,139 @@
+# Architecture — where to find what
+
+Reversee is an Electron app whose job is to run a reverse proxy and let both
+humans (the UI) and agents (MCP) inspect and control it. The design keeps the
+proxy logic isolated and headless-testable, and exposes a small, audited surface
+to the renderer and to agents.
+
+## Process model
+
+```
+                         ┌──────────────────────────────────────┐
+                         │            Electron MAIN              │
+                         │  src/main/index.ts (lifecycle, IPC)   │
+   ┌─────────────┐  IPC  │                                       │
+   │  RENDERER   │◄─────►│  proxy-host.ts ──┐  settings.ts       │
+   │ React UI    │       │  traffic-store   │  certs/  updater   │
+   │ src/renderer│       │  windows  menu   │                    │
+   └─────┬───────┘       │                  │   mcp/ control     │
+         │ window.reversee│                 │   socket           │
+   ┌─────▼───────┐       └────────┬─────────┴────────┬───────────┘
+   │  PRELOAD    │                │ parentPort        │ unix socket /
+   │ src/preload │       postMessage (typed)          │ named pipe (token)
+   │ RevAPI      │                ▼                    ▼
+   └─────────────┘   ┌────────────────────┐   ┌──────────────────────┐
+                     │  PROXY WORKER      │   │  reversee-mcp BRIDGE │
+                     │  utilityProcess    │   │  (stdio MCP server)  │
+                     │  src/proxy/worker  │   │  mcp/src/cli.ts      │
+                     │  + core/ (no       │   └──────────┬───────────┘
+                     │    Electron)       │              │ stdio
+                     └────────────────────┘        ┌─────▼──────┐
+                                                    │ MCP client │
+                                                    │ (agent)    │
+                                                    └────────────┘
+```
+
+Four boundaries, each typed:
+
+- **Renderer ⇄ Main** — allowlisted IPC channels exposed through the preload bridge
+  as `window.reversee` (typed `RevAPI`). The renderer never touches `ipcRenderer`.
+- **Main ⇄ Proxy worker** — `parentPort.postMessage` with typed
+  `WorkerInbound`/`WorkerOutbound` messages. The worker is a `utilityProcess` that
+  can be killed and respawned to recover a wedged interceptor.
+- **Main ⇄ MCP bridge** — a token-authenticated local Unix socket / Windows named
+  pipe (never TCP). See [ADR 0003](adr/0003-gated-mcp-mutations-over-local-socket.md).
+- **Bridge ⇄ agent** — stdio MCP.
+
+## `src/main/` — Electron main process
+
+System integration, state, and the MCP control surface.
+
+| File | Responsibility |
+| --- | --- |
+| `index.ts` | App lifecycle, IPC registration, proxy startup, MCP socket init, headless mode (`--headless`). |
+| `proxy-host.ts` | Owns the proxy `utilityProcess`: spawn, message routing, restart, teardown. |
+| `settings.ts` | Persistence via electron-store; validation and change listeners. |
+| `traffic-store.ts` | Ring buffer (capped) of captured traffic entries. |
+| `windows.ts` | BrowserWindow creation and lifecycle. |
+| `menu.ts` | Application menu, including the MCP setup item and cache reset. |
+| `updater.ts` | electron-updater auto-update integration. |
+| `certs/certs.ts` | Root CA generation/persistence (node-forge) for HTTPS interception. |
+| `cli-args.ts` | CLI flag parsing (`--headless`, `--allow-mcp-control`). |
+
+### `src/main/mcp/` — control socket + tool catalog
+
+| File | Responsibility |
+| --- | --- |
+| `catalog.ts` | **The authoritative MCP tool catalog** + the bridge-version advisory. Single source of truth. |
+| `control-server.ts` | Local socket / named pipe server; per-boot token auth; rejects mutating methods unless control is enabled. |
+| `handlers.ts` | Implements each tool, backed by main's stores. |
+
+## `src/preload/index.ts` — the renderer bridge
+
+The only bridge. Exposes a typed `RevAPI` as `window.reversee` over an allowlist of
+IPC channels (proxy control, settings, traffic, breakpoints, clipboard, and event
+subscriptions). Raw `ipcRenderer` is never exposed.
+
+## `src/renderer/` — React UI
+
+Entry: `src/renderer/src/main.tsx` → `App.tsx`.
+
+- **Stores** (`src/renderer/src/stores/`): `proxyStore.ts` (traffic mirror, proxy
+  state, settings), `breakpointStore.ts` (rules, FIFO hit queue, compile errors),
+  `uiStore.ts` (dialog state).
+- **Components** (`src/renderer/src/components/`): `SettingsBar.tsx`,
+  `TrafficTable.tsx`, `DetailPanes.tsx`, `BreakpointsDialog.tsx`,
+  `BreakpointQueue.tsx`, `InterceptorPanel.tsx`, `ConnectAiDialog.tsx`,
+  `MonacoView.tsx` / `MonacoViewImpl.tsx` (JS editor for interceptors), and `ui/`
+  (Radix-based primitives).
+
+## `src/proxy/` — the proxy core (Electron-free)
+
+`core/` is plain Node with **no Electron imports** (ESLint-enforced) so it can be
+unit-tested headlessly — see [ADR 0001](adr/0001-electron-free-proxy-core.md).
+
+| File | Responsibility |
+| --- | --- |
+| `worker.ts` | `utilityProcess` entry; speaks typed messages over `parentPort`; owns breakpoint gating and server lifecycle. |
+| `core/server.ts` | HTTP/HTTPS listener; buffers request bodies; calls the optional gate (breakpoints) then proxies. |
+| `core/proxy.ts` | Upstream connect, request/response forwarding, decompression, traffic recording. |
+| `core/interceptor.ts` | VM-sandboxed JS execution for request/response mutation. |
+| `core/breakpoints.ts` | Regex compilation and URL + method matching. |
+| `core/curl.ts` | Builds copy-pasteable curl commands from captured requests. |
+
+## `src/shared/` — cross-process contracts
+
+- `ipc.ts` — the `RevAPI` interface, `WorkerInbound`/`WorkerOutbound` message
+  types, and IPC channel names (`domain:action`).
+- `types.ts` — core types: `ProxySettings`, `RequestParams`, `TrafficEntry`,
+  `BreakpointRule`, `Headers`, `Logger`.
+- `settings-schema.ts` — `AppSettings` shape, defaults, and sanitization (port
+  range, protocol enum, booleans).
+
+## `mcp/` — the `reversee-mcp` bridge (separate npm package)
+
+| File | Responsibility |
+| --- | --- |
+| `src/cli.ts` | stdio MCP server entry; fetches the catalog from the running app, falls back to the frozen copy. |
+| `src/client.ts` | ndjson client for the control socket; token auth, lifecycle, error recovery. |
+| `src/catalog.ts` | Frozen fallback catalog (used only when the app is down). |
+
+The app owns the catalog and serves it to the bridge at startup, so tools added in
+app updates reach agents without republishing the bridge —
+[ADR 0002](adr/0002-app-owns-mcp-tool-catalog.md).
+
+## Common change → files to touch
+
+- **Add an MCP tool** — define it in `src/main/mcp/catalog.ts` (set `mutating: true`
+  if it changes state), implement it in `src/main/mcp/handlers.ts`, and assert it in
+  the catalog test (`tests/unit/`, see [TESTING.md](../TESTING.md)). The bridge and
+  the gated-mutation set update automatically.
+- **Add a setting** — extend `src/shared/settings-schema.ts` (shape + default +
+  sanitization) and `ProxySettings`/`AppSettings` in `src/shared/`, wire it through
+  `settings.ts`, surface it in `SettingsBar.tsx`, and consume it in the proxy
+  (`src/proxy/core/`). Mention it in `update_config`'s description in `catalog.ts`.
+- **Change proxy behavior** — work in `src/proxy/core/` (keep it Electron-free) and
+  the typed worker messages in `src/shared/ipc.ts`.
+- **Add a UI panel** — add a component under `src/renderer/src/components/`, hold its
+  state in a store under `src/renderer/src/stores/`, and add any new IPC through
+  `src/preload/index.ts` + the channel allowlist + `src/shared/ipc.ts`.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,55 @@
+# Conventions
+
+Process and code conventions for working in this repo. The full contribution
+walkthrough is in [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Quality gates
+
+- **`npm run lint` and `npm run typecheck` must pass before committing** — both gate
+  CI, on the app *and* the `mcp/` workspace.
+- `npm run format` (prettier) keeps formatting consistent.
+
+## Testing
+
+Four layers — unit/integration + MCP e2e (Vitest, `tests/unit/`), app e2e
+(Playwright, `tests/e2e/`), and packaged smoke (release-only, `tests/smoke/`). All
+but the packaged smoke run on every PR. **Read [TESTING.md](../TESTING.md) before
+adding or changing tests** — it says which layer a change belongs in and how the
+layers map to CI jobs.
+
+## Architecture rules
+
+- **Keep the proxy core Electron-free.** `src/proxy/core/` is plain Node, enforced by
+  ESLint, so it stays headless-testable —
+  [ADR 0001](adr/0001-electron-free-proxy-core.md).
+- **The app owns the MCP tool catalog.** New tools are defined in
+  `src/main/mcp/catalog.ts` (the single source of truth for the bridge and the
+  gated-mutation set), not in the bridge —
+  [ADR 0002](adr/0002-app-owns-mcp-tool-catalog.md).
+- **The preload is the only renderer bridge** — expose new capabilities through the
+  `RevAPI` allowlist, never raw `ipcRenderer`.
+
+## Releases
+
+Releases are **tag-driven** — never hand-publish. A `v*` tag drives a gated pipeline
+(build → verify-mac → promote → homebrew). See [RELEASING.md](../RELEASING.md) and
+[ADR 0004](adr/0004-tag-driven-release-pipeline.md).
+
+## Security
+
+- macOS builds are signed + notarized in CI. **Never commit secrets or certificates.**
+- The MCP control surface is local-socket + token-authenticated, with mutations
+  gated — [ADR 0003](adr/0003-gated-mcp-mutations-over-local-socket.md).
+
+## Related repositories and artifacts
+
+| Artifact | Where | Notes |
+| --- | --- | --- |
+| App source (this repo) | `galusben/reversee` | The Electron app + the `mcp/` workspace. |
+| Homebrew cask tap | `galusben/homebrew-reversee` | Auto-updated on stable releases by the release pipeline. |
+| MCP bridge (npm) | `reversee-mcp` | <https://www.npmjs.com/package/reversee-mcp>. Built from `mcp/`. |
+| Landing site | GitHub Pages from `docs/` | <https://galusben.github.io/reversee/>. |
+| Homepage | reversee.ninja | Marketing site. |
+| Releases | GitHub Releases | <https://github.com/galusben/reversee/releases>. |
+
+License: MIT.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,76 @@
+# Features — for humans and for agents
+
+Reversee exposes the same reverse-proxy debugger to two audiences: humans through
+the desktop UI, and agents through the Model Context Protocol.
+
+## Human / UI
+
+- **Configure the proxy** — listen protocol (http/https) + port, destination
+  protocol + host + port. Toggles: *rewrite host* (override the Host header),
+  *rewrite redirects* (rewrite 3xx `Location`), *allow self-signed upstream*.
+- **Start / stop** — from the settings bar; status shows the listen port or the
+  error (e.g. `EADDRINUSE`).
+- **Inspect traffic** — a table of method / URL / status / content-type; click a row
+  for full request & response in the detail panes (headers, gzip/brotli-decoded and
+  syntax-highlighted bodies, timings). Copy-as-curl from the context menu; scroll
+  lock to stop auto-follow; clear all.
+- **Interceptors** — toggle request/response interception and edit JavaScript in a
+  Monaco editor to mutate `requestParams` (host, path, method, port, headers, body)
+  or `responseParams` (statusCode, headers, body) live. User-code errors are
+  sandboxed and don't crash the proxy.
+- **Breakpoints** — hold requests matching a URL regex + HTTP methods; held requests
+  land in a FIFO queue where you edit URL/headers/body and resume.
+- **Connect AI** — a dialog with the `npx reversee-mcp` setup, plus the toggle that
+  gates agent control.
+- **Root CA trust** — a locally generated root certificate so HTTPS interception is
+  trusted.
+
+The UI is React; state lives in Zustand stores and components under
+`src/renderer/src/` (see [architecture.md](architecture.md)).
+
+## Agent / MCP
+
+Agents drive the running app through the `reversee-mcp` stdio bridge. Setup is in
+[mcp/README.md](../mcp/README.md) and [../README.md](../README.md).
+
+### The control model
+
+- **Read-only tools are always available.** Mutating tools (change config, start /
+  stop / restart the proxy) are **gated**: rejected unless the user enables
+  "Allow MCP to Control the Proxy" in the app, or the app is launched headless with
+  `--allow-mcp-control`.
+- **Transport is local and authenticated** — a per-boot token over a Unix socket /
+  Windows named pipe (mode 0600), never a TCP port. See
+  [ADR 0003](adr/0003-gated-mcp-mutations-over-local-socket.md).
+- **The app owns the tool catalog** and serves it to the bridge at startup, so new
+  tools ship with app updates — see
+  [ADR 0002](adr/0002-app-owns-mcp-tool-catalog.md).
+
+### Tools
+
+> Source of truth: `MCP_TOOL_CATALOG` in
+> [`src/main/mcp/catalog.ts`](../src/main/mcp/catalog.ts). The table below is a
+> summary — the catalog has the exact input schemas and descriptions.
+
+| Tool | Purpose | Mutating? |
+| --- | --- | --- |
+| `get_status` | App version, proxy run state, listen/dest config, traffic & breakpoint counts. | no |
+| `get_config` | Full proxy configuration. | no |
+| `update_config` | Patch the configuration (partial settings object). | **yes** |
+| `start_proxy` | Start the proxy with the current config. | **yes** |
+| `stop_proxy` | Stop the proxy. | **yes** |
+| `restart_proxy` | Restart the worker (recovers a wedged interceptor). | **yes** |
+| `list_traffic` | Paged captured requests; bodies elided. | no |
+| `get_traffic_entry` | One request in full: headers, bodies, timings, curl. | no |
+| `list_breakpoints` | The configured breakpoint rules. | no |
+| `validate_setup` | Setup checks: destination, ports, root cert, proxy process. | no |
+| `export_diagnostics` | Versions, platform, settings, state, log location — for bug reports. | no |
+
+11 tools; the 4 marked mutating are gated.
+
+### Headless mode
+
+`reversee --headless --allow-mcp-control` runs with no window — just the proxy + MCP
+socket — until killed, for CI- or agent-driven automation. Set a distinct
+`REVERSEE_USER_DATA` directory to isolate an agent's instance (and its control
+socket) from a GUI instance.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -47,7 +47,11 @@ Headless mode (agent- or CI-driven, no UI):
 ## Documentation
 
 - [README](https://github.com/galusben/reversee/blob/main/README.md): features, install, MCP setup, headless mode, development.
+- [Agent guide](https://github.com/galusben/reversee/blob/main/AGENTS.md): the canonical entry point for AI agents working in the repo.
+- [Knowledge base](https://github.com/galusben/reversee/blob/main/docs/README.md): code map, feature catalog, conventions, and decisions.
+- [Architecture](https://github.com/galusben/reversee/blob/main/docs/architecture.md): where to find what in the codebase.
+- [Contributing](https://github.com/galusben/reversee/blob/main/CONTRIBUTING.md): setup and the change workflow.
+- [Decision records](https://github.com/galusben/reversee/blob/main/docs/adr/README.md): the key architecture decisions and why.
 - [Testing](https://github.com/galusben/reversee/blob/main/TESTING.md): the test layers and how they map to CI.
 - [Releasing](https://github.com/galusben/reversee/blob/main/RELEASING.md): the tag-driven release pipeline.
-- [Agent guide](https://github.com/galusben/reversee/blob/main/CLAUDE.md): orientation for AI agents working in the repo.
 - [reversee-mcp package](https://github.com/galusben/reversee/blob/main/mcp/README.md): the MCP bridge's tools and security model.


### PR DESCRIPTION
## What

Adds a structured knowledge base so agents and new contributors can learn Reversee fast.

- **`AGENTS.md`** — vendor-neutral agent entry hub (commands, code map, working agreements, runtime MCP model). `CLAUDE.md` shrinks to a pointer at it.
- **`docs/architecture.md`** — the code map: process-model diagram, every source area with entry-point files, and "common change → files to touch" recipes.
- **`docs/features.md`** — human (UI) + agent (MCP) capability catalog: the 11 tools + the gated-mutation model.
- **`docs/conventions.md`** — conventions + a map of related repos/artifacts (homebrew tap, `reversee-mcp` npm, Pages site).
- **`docs/adr/`** — index + 5 Architecture Decision Records (Electron-free core, app-owns-catalog, gated MCP socket, tag-driven releases, and one capturing the deferred S3-migration / code-signing / MCP-on-by-default questions).
- **`CONTRIBUTING.md`** — setup + change workflow.
- **`README.md` / `docs/llms.txt`** — link into the new KB.

## Design

No design facts are duplicated — `RELEASING.md`, `TESTING.md`, and `src/main/mcp/catalog.ts` stay authoritative and are linked, not copied.

## Verification

- No app code changed.
- All code paths named in `architecture.md` exist; MCP facts match `catalog.ts` (11 tools, 4 mutating).
- All relative links across the new/edited docs resolve.
- `npm run lint` and `npm run typecheck` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)