### PR TITLE
feat(grpc): HTTP/2 transport — proxy and decode live gRPC (M2 + M3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Reversee sits between your client and a destination server. Point your client at
 - **Traffic inspection** — method, path, status, content type, headers, request/response bodies (plain and formatted), and per-request timings (DNS, TCP, TLS, first byte, total).
 - **Interceptors** — JavaScript snippets that rewrite requests (`requestParams`: host, path, method, port, headers, body) or responses (`responseParams`: statusCode, headers, body) on the fly.
 - **Breakpoints** — hold requests matching a URL regex + methods, edit the URL, headers, and body, then continue.
-- **gRPC proto specs** — import `.proto` files or compiled `.desc` FileDescriptorSets (*gRPC → Proto Specs*, or via MCP); Reversee uses them to decode gRPC messages into readable JSON, matched by method. See [gRPC](#grpc).
+- **gRPC** — proxy native gRPC over HTTP/2 (h2 via ALPN, or cleartext h2c) and decode every message — unary and server/client/bidi streaming — into readable JSON, using `.proto`/`.desc` definitions you import. See [gRPC](#grpc).
 - **Redirect & host rewriting** — keep redirect chains and Host headers pointed at the proxy.
 - **MCP integration** — let Claude Code, Cursor, or any MCP client inspect and (optionally) control the proxy. See below.
 
@@ -54,13 +54,14 @@ The request appears in the traffic table; click it to inspect.
 
 ## gRPC
 
-Protobuf wire bytes carry only field numbers, so gRPC is unreadable without the schema. Reversee decodes it from protobuf definitions you supply:
+Reversee proxies native gRPC and decodes the protobuf messages — wire bytes carry only field numbers, so it decodes them against definitions you supply.
 
-1. Open **gRPC → Proto Specs** and import a `.proto` file or a compiled `.desc` FileDescriptorSet (no `protoc` needed for `.proto` — Reversee parses it directly).
-2. Specs are saved across restarts and matched to calls by gRPC method (`/package.Service/Method`). Compile errors surface in the dialog.
-3. Agents can manage the same specs over MCP with `list_proto_specs` / `add_proto_spec` / `remove_proto_spec`.
+1. Check **gRPC** in the settings bar. This runs an HTTP/2 listener: with an `https` listen protocol it negotiates h2 via ALPN; with `http` it speaks cleartext h2c (prior knowledge). Point your gRPC client at the listen port.
+2. Open **gRPC → Proto Specs** and import a `.proto` file or a compiled `.desc` FileDescriptorSet (no `protoc` needed for `.proto` — Reversee parses it directly). Specs are saved across restarts and matched to calls by method (`/package.Service/Method`); compile errors surface in the dialog.
+3. Each call shows in the traffic table with a **gRPC** badge and its `grpc-status`. The detail pane's **gRPC** tab renders every request/response message as JSON (all four call types — unary and server/client/bidi streaming — with each streamed message listed), alongside the raw bytes.
+4. Agents can manage specs over MCP with `list_proto_specs` / `add_proto_spec` / `remove_proto_spec`, and `get_traffic_entry` returns the decoded messages and status.
 
-Decoded request/response messages render as JSON next to the raw bytes. Capturing **native gRPC over HTTP/2** is the next milestone — the proxy core currently speaks HTTP/1.1 — so the spec management and decoding engine ship first, with live capture to follow.
+Enabling gRPC turns the listener into HTTP/2-only, so plain HTTP/1.1 isn't served on that port while it's on.
 
 ## MCP integration (Claude Code / Cursor)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -16,7 +16,7 @@ Reversee has four test layers. All of them except the packaged smoke test run on
 ### Unit & integration (`tests/unit/`)
 - **Proxy core** (`proxy.core`, `interceptor`, `curl`, `breakpoints`) — the request-forwarding logic, run headlessly against real `http`/`https` fixture servers (no Electron). This is the safety net the whole refactor was built on.
 - **Traffic store** (`traffic-store`) — ring-buffer cap, eviction, body truncation.
-- **gRPC** (`grpc-frames`, `grpc-registry`, `proto-store`) — length-prefixed framing (multi-frame, compression, truncation, incremental accumulator), proto-spec CRUD on disk, `.proto`/`.desc` compilation + method-map building, and registry resolution decoding a frame end-to-end. All headless (protobufjs is pure JS; the store takes a directory).
+- **gRPC** (`grpc-frames`, `grpc-registry`, `proto-store`, `grpc-proxy`) — length-prefixed framing (multi-frame, compression, truncation, incremental accumulator), proto-spec CRUD on disk, `.proto`/`.desc` compilation + method-map building, registry resolution, and a full round-trip through `createHttp2ProxyServer` against a hand-rolled h2c gRPC upstream (unary, server-streaming, and a non-OK Trailers-Only status — asserting decoded JSON both ways, the captured grpc-status, and raw passthrough). All headless (protobufjs and `node:http2` are dependency-light).
 - **MCP** — `control-server` (token handshake, gating, permissions), `mcp-catalog` (the app-owned tool catalog + derived mutating set), `mcp-bridge` (`resolveCatalog` against the real control server incl. offline fallback, version-advisory logic), `mcp-client` (the bridge's socket client against the real server).
 
 ### App end-to-end (`tests/e2e/`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,8 +98,9 @@ unit-tested headlessly — see [ADR 0001](adr/0001-electron-free-proxy-core.md).
 | File | Responsibility |
 | --- | --- |
 | `worker.ts` | `utilityProcess` entry; speaks typed messages over `parentPort`; owns breakpoint gating and server lifecycle. |
-| `core/server.ts` | HTTP/HTTPS listener; buffers request bodies; calls the optional gate (breakpoints) then proxies. |
+| `core/server.ts` | HTTP/1.1 HTTP/HTTPS listener; buffers request bodies; calls the optional gate (breakpoints) then proxies. |
 | `core/proxy.ts` | Upstream connect, request/response forwarding, decompression, traffic recording. |
+| `core/http2.ts` | HTTP/2 listener used when `enableGrpc` is set; per-stream forward with gRPC frame decode both directions and grpc-status trailer capture (unary + streaming). |
 | `core/interceptor.ts` | VM-sandboxed JS execution for request/response mutation. |
 | `core/breakpoints.ts` | Regex compilation and URL + method matching. |
 | `core/curl.ts` | Builds copy-pasteable curl commands from captured requests. |
@@ -109,24 +110,34 @@ unit-tested headlessly — see [ADR 0001](adr/0001-electron-free-proxy-core.md).
 ## gRPC decoding
 
 Protobuf wire bytes carry only field numbers, so gRPC is unreadable without the
-schema. Reversee decodes it from user-supplied proto definitions, split across the
-process boundary to keep the proxy core Electron-free:
+schema. Reversee proxies native gRPC and decodes it from user-supplied proto
+definitions, split across the process boundary to keep the proxy core
+Electron-free:
 
+- **Transport** (`src/proxy/core/http2.ts`) — when `enableGrpc` is set the worker
+  runs this HTTP/2 listener instead of the HTTP/1.1 server (gRPC needs HTTP/2
+  framing + trailers). `https` negotiates h2 via ALPN; `http` speaks cleartext h2c.
+  For each stream it opens an upstream HTTP/2 stream, pipes bytes both ways
+  **unmodified**, and copies frames through a `FrameAccumulator` to decode messages
+  as they arrive (so streaming calls fill in incrementally), capturing the
+  `grpc-status` trailer. It re-emits the `TrafficEntry` on each frame (the store
+  upserts by `trafficId`). gRPC mode is HTTP/2-only — HTTP/1.1 isn't served because
+  mixing the native stream API with the compatibility layer double-sends trailers.
 - **Main** (`src/main/proto/proto-store.ts`) stores `.proto`/`.desc` specs and
   `compile()`s them (protobufjs — no `protoc`) into a serializable bundle: one
   namespace per spec plus a `/package.Service/Method` → type map. The bundle ships
   to the worker via the `set-proto-specs` `WorkerInbound` message — the same
   spec-compile-and-push pattern as breakpoints.
-- **Worker/core** (`src/proxy/core/grpc-registry.ts` + `grpc-frames.ts`) rebuilds
-  the bundle and, for a captured call, parses the length-prefixed frames and decodes
-  each against the resolved message type into JSON (`TrafficEntry.grpc`).
-- **Surfaced** to humans in `DetailPanes.tsx` and to agents via `get_traffic_entry`.
-  Specs are managed in the UI (`ProtoSpecsDialog`) and over MCP
-  (`list_proto_specs` / `add_proto_spec` / `remove_proto_spec`).
+- **Decode** (`src/proxy/core/grpc-registry.ts` + `grpc-frames.ts`) rebuilds the
+  bundle, resolves a call's `:path` to request/response types, and decodes each
+  frame into JSON (`TrafficEntry.grpc`).
+- **Surfaced** to humans in `DetailPanes.tsx` (the gRPC tab) + `TrafficTable.tsx`
+  (badge + grpc-status) and to agents via `get_traffic_entry`. Specs are managed in
+  the UI (`ProtoSpecsDialog`) and over MCP (`list_proto_specs` / `add_proto_spec` /
+  `remove_proto_spec`).
 
 `protobufjs` is bundled into both `index.js` and `proxyWorker.js` (electron-vite
-bundles deps). The HTTP/2 transport that captures live native gRPC is a follow-up;
-spec management and the decode engine land first, exercised by unit tests.
+bundles deps). Breakpoint gating stays on the HTTP/1.1 path for now.
 
 ## `src/shared/` — cross-process contracts
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,11 +20,12 @@ the desktop UI, and agents through the Model Context Protocol.
   sandboxed and don't crash the proxy.
 - **Breakpoints** — hold requests matching a URL regex + HTTP methods; held requests
   land in a FIFO queue where you edit URL/headers/body and resume.
-- **gRPC proto specs** — import `.proto` files or compiled `.desc` FileDescriptorSets
-  (*gRPC → Proto Specs*); Reversee compiles them (protobufjs, no `protoc`) and uses
-  them to decode gRPC messages into JSON, matched by method
-  (`/package.Service/Method`). Spec management and the decode engine ship now; live
-  native-gRPC (HTTP/2) capture is the next milestone.
+- **gRPC** — check *gRPC* in the settings bar to run an HTTP/2 listener (h2 via ALPN
+  on https, cleartext h2c on http) that proxies native gRPC. Import `.proto`/`.desc`
+  definitions (*gRPC → Proto Specs*; protobufjs, no `protoc`) and every message —
+  unary and server/client/bidi streaming — is decoded into JSON in the detail pane's
+  gRPC tab, with the `grpc-status` shown on the row. Matched by method
+  (`/package.Service/Method`). gRPC mode is HTTP/2-only on that port.
 - **Connect AI** — a dialog with the `npx reversee-mcp` setup, plus the toggle that
   gates agent control.
 - **Root CA trust** — a locally generated root certificate so HTTPS interception is

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -8,7 +8,7 @@
 - Inspect traffic: method, path, status, content type, headers, request/response bodies (gzip/brotli decoded, syntax-highlighted), per-request timings, and a copy-as-curl command.
 - Interceptors: rewrite requests (`requestParams`: host, path, method, port, headers, body) or responses (`responseParams`: statusCode, headers, body) with JavaScript, live.
 - Breakpoints: hold requests matching a URL regex + HTTP methods, edit the URL/headers/body, then resume.
-- gRPC: import `.proto` or compiled `.desc` protobuf definitions; Reversee uses them to decode gRPC messages into JSON, matched by method (`/package.Service/Method`). Spec management and the decoding engine ship now; native gRPC (HTTP/2) capture is the next milestone.
+- gRPC: enable an HTTP/2 listener (h2 via ALPN on https, cleartext h2c on http) to proxy native gRPC; import `.proto` or compiled `.desc` protobuf definitions and Reversee decodes every message — unary and server/client/bidi streaming — into JSON, matched by method (`/package.Service/Method`), and captures the grpc-status trailer.
 - Redirect and Host-header rewriting; a locally generated root CA for trusting HTTPS interception.
 - Source: https://github.com/galusben/reversee — License: MIT.
 

--- a/src/main/mcp/catalog.ts
+++ b/src/main/mcp/catalog.ts
@@ -86,7 +86,8 @@ export const MCP_TOOL_CATALOG: McpToolDef[] = [
       'Update Reversee configuration. Accepts a partial settings object; unknown keys and invalid values are ignored. ' +
       'Keys: listenProtocol/destProtocol (http|https), listenPort/destPort (1-65535), dest (host), ' +
       'interceptRequest/interceptResponse (bool), requestInterceptor/responseInterceptor (JS source), ' +
-      'rewriteRedirects/rewriteHost/allowSelfSignedUpstream (bool). ' +
+      'rewriteRedirects/rewriteHost/allowSelfSignedUpstream/enableGrpc (bool). ' +
+      'enableGrpc runs an HTTP/2 listener so native gRPC is proxied and decoded (against saved proto specs). ' +
       'Requires "Allow MCP to Control the Proxy" enabled in the app. Returns the resulting config.',
     inputSchema: {
       type: 'object',

--- a/src/proxy/core/http2.ts
+++ b/src/proxy/core/http2.ts
@@ -1,0 +1,284 @@
+// HTTP/2 reverse proxy with gRPC awareness. Used instead of the HTTP/1.1
+// server (core/server.ts) when `enableGrpc` is set, so native gRPC — which
+// requires HTTP/2 framing and trailers — can be proxied and decoded.
+//
+// For each inbound stream it opens an upstream HTTP/2 stream to the fixed
+// destination and pipes bytes both ways UNMODIFIED (the wire is never altered),
+// while copying frames through a FrameAccumulator to decode gRPC messages and
+// capturing the grpc-status trailer. Works for unary and all streaming modes:
+// messages accumulate as DATA frames arrive and the traffic entry is re-emitted
+// (the store upserts by trafficId).
+//
+// Electron-free (node:http2 only). This is an HTTP/2-only listener: https
+// negotiates h2 via ALPN, http speaks cleartext h2c (prior knowledge). Plain
+// HTTP/1.1 is not served in gRPC mode — mixing the native 'stream' API (needed
+// for trailers) with the HTTP/1.1 compatibility layer double-sends trailers.
+import http2 from 'node:http2';
+import { FrameAccumulator, decodeFrame } from './grpc-frames';
+import type { ResolvedMethod } from './grpc-registry';
+import type { ProxyServer, SslOptions } from './server';
+import type {
+  GrpcView,
+  Headers,
+  Logger,
+  ProxySettings,
+  RequestView,
+  ResponseView,
+  Timings,
+  TrafficEntry,
+} from '../../shared/types';
+
+export interface Http2ProxyServerOptions {
+  settings: ProxySettings;
+  notify: (entry: TrafficEntry) => void;
+  sslOptions?: SslOptions;
+  /** Resolves a gRPC `:path` to the message types that decode its frames. */
+  resolveMethod?: (path: string) => ResolvedMethod | undefined;
+  logger?: Logger;
+  onServerError?: (err: NodeJS.ErrnoException) => void;
+}
+
+const noop: Logger = { debug() {}, info() {}, warn() {}, error() {} };
+
+let trafficId = 0;
+
+/** HTTP/2 headers we manage ourselves and must not copy between streams. */
+const HOP_BY_HOP = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-connection',
+  'transfer-encoding',
+  'upgrade',
+  'host',
+]);
+
+/** Copy real (non-pseudo, non-hop-by-hop) headers into our serializable shape. */
+function viewHeaders(h: http2.IncomingHttpHeaders | http2.OutgoingHttpHeaders): Headers {
+  const out: Headers = {};
+  for (const key of Object.keys(h)) {
+    if (key.startsWith(':') || HOP_BY_HOP.has(key)) continue;
+    out[key] = h[key] as string | string[] | undefined;
+  }
+  return out;
+}
+
+export function createHttp2ProxyServer(options: Http2ProxyServerOptions): ProxyServer {
+  const { settings, notify } = options;
+  const logger = options.logger ?? noop;
+  const rejectUnauthorized = settings.allowSelfSignedUpstream === false;
+  const upstreamOrigin = `${settings.destProtocol === 'https' ? 'https' : 'http'}://${settings.dest}:${settings.destPort}`;
+
+  const server =
+    settings.listenProtocol === 'https'
+      ? http2.createSecureServer({
+          key: options.sslOptions?.key,
+          cert: options.sslOptions?.cert,
+        })
+      : http2.createServer();
+
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    logger.error('http2 proxy server error', err);
+    options.onServerError?.(err);
+  });
+
+  // HTTP/2 streams (the gRPC path).
+  server.on(
+    'stream',
+    (clientStream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders) => {
+      forwardStream(clientStream, headers, {
+        settings,
+        notify,
+        logger,
+        rejectUnauthorized,
+        upstreamOrigin,
+        resolveMethod: options.resolveMethod,
+      });
+    }
+  );
+
+  return {
+    get listening(): boolean {
+      return server.listening;
+    },
+    listen(): Promise<number> {
+      return new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(settings.listenPort, () => {
+          server.removeListener('error', reject);
+          const address = server.address();
+          const port = typeof address === 'object' && address ? address.port : settings.listenPort;
+          logger.info(`http2 proxy listening on ${settings.listenProtocol}://localhost:${port}`);
+          resolve(port);
+        });
+      });
+    },
+    close(): Promise<void> {
+      return new Promise((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}
+
+interface ForwardContext {
+  settings: ProxySettings;
+  notify: (entry: TrafficEntry) => void;
+  logger: Logger;
+  rejectUnauthorized: boolean;
+  upstreamOrigin: string;
+  resolveMethod?: (path: string) => ResolvedMethod | undefined;
+}
+
+function forwardStream(
+  clientStream: http2.ServerHttp2Stream,
+  headers: http2.IncomingHttpHeaders,
+  ctx: ForwardContext
+): void {
+  const { settings, notify, logger, resolveMethod } = ctx;
+  const startAt = process.hrtime.bigint();
+  const timings: Timings = { start: new Date() };
+
+  const path = String(headers[':path'] ?? '');
+  const method = String(headers[':method'] ?? 'POST');
+  const contentType = String(headers['content-type'] ?? '');
+  const isGrpc = contentType.startsWith('application/grpc');
+  const resolved = isGrpc ? resolveMethod?.(path) : undefined;
+
+  const requestView: RequestView = {
+    url: path,
+    method,
+    headers: viewHeaders(headers),
+    body: Buffer.alloc(0),
+    target: { protocol: settings.destProtocol, host: settings.dest, port: settings.destPort },
+  };
+  const responseView: ResponseView = { headers: {}, body: Buffer.alloc(0) };
+  const grpc: GrpcView | undefined = isGrpc
+    ? { method: path, requestMessages: [], responseMessages: [], matchedSpecId: resolved?.specId }
+    : undefined;
+  const entry: TrafficEntry = {
+    trafficId: trafficId++,
+    request: requestView,
+    response: responseView,
+    timings,
+    grpc,
+  };
+  notify(entry); // surface the row immediately; re-emitted as frames/trailers arrive
+
+  const session = http2.connect(ctx.upstreamOrigin, { rejectUnauthorized: ctx.rejectUnauthorized });
+  session.on('error', (err) => {
+    logger.info('grpc upstream error', err);
+    entry.connectorError = err;
+    responseView.statusCode = 502;
+    notify(entry);
+    if (!clientStream.closed) clientStream.close(http2.constants.NGHTTP2_INTERNAL_ERROR);
+    session.close();
+  });
+
+  // Build the upstream request headers: keep gRPC/content headers, drop the
+  // inbound pseudo-headers and hop-by-hop, and let http2 set :authority/:scheme.
+  const outHeaders: http2.OutgoingHttpHeaders = { ':method': method, ':path': path };
+  for (const key of Object.keys(headers)) {
+    if (key.startsWith(':') || HOP_BY_HOP.has(key)) continue;
+    outHeaders[key] = headers[key];
+  }
+  const upstream = session.request(outHeaders);
+
+  // --- request direction: client -> upstream (raw passthrough + decode copy) ---
+  const reqAcc = new FrameAccumulator();
+  const reqRaw: Buffer[] = [];
+  clientStream.on('data', (chunk: Buffer) => {
+    upstream.write(chunk);
+    reqRaw.push(chunk);
+    if (grpc) {
+      for (const frame of reqAcc.push(chunk)) {
+        grpc.requestMessages.push(decodeFrame(frame, resolved?.requestType));
+      }
+      notify(entry);
+    }
+  });
+  clientStream.on('end', () => {
+    upstream.end();
+    requestView.body = Buffer.concat(reqRaw);
+  });
+  clientStream.on('error', (err) => {
+    logger.info('grpc client stream error', err);
+    if (!upstream.closed) upstream.close(http2.constants.NGHTTP2_INTERNAL_ERROR);
+  });
+
+  // --- response direction: upstream -> client ---
+  const respAcc = new FrameAccumulator();
+  const respRaw: Buffer[] = [];
+  let trailers: Headers = {};
+
+  upstream.on('response', (respHeaders) => {
+    timings.firstByte = Number(process.hrtime.bigint() - startAt);
+    responseView.statusCode = Number(respHeaders[':status']) || undefined;
+    responseView.headers = viewHeaders(respHeaders);
+
+    // gRPC "Trailers-Only": status rides in the response HEADERS (END_STREAM,
+    // no DATA). Capture the status and forward the headers as a final frame.
+    const trailersOnly = respHeaders['grpc-status'] !== undefined;
+    if (grpc && trailersOnly) {
+      grpc.status = Number(respHeaders['grpc-status']);
+      grpc.statusMessage = grpcMessage(respHeaders['grpc-message']);
+    }
+
+    if (clientStream.closed) return;
+    clientStream.respond(downstreamHeaders(respHeaders), { waitForTrailers: !trailersOnly });
+    notify(entry);
+  });
+
+  clientStream.on('wantTrailers', () => {
+    clientStream.sendTrailers(trailers as http2.OutgoingHttpHeaders);
+  });
+
+  upstream.on('data', (chunk: Buffer) => {
+    if (!clientStream.closed) clientStream.write(chunk);
+    respRaw.push(chunk);
+    if (grpc) {
+      for (const frame of respAcc.push(chunk)) {
+        grpc.responseMessages.push(decodeFrame(frame, resolved?.responseType));
+      }
+      notify(entry);
+    }
+  });
+  upstream.on('trailers', (t) => {
+    trailers = viewHeaders(t);
+    if (grpc) {
+      grpc.status = t['grpc-status'] !== undefined ? Number(t['grpc-status']) : grpc.status;
+      grpc.statusMessage = grpcMessage(t['grpc-message']) ?? grpc.statusMessage;
+    }
+  });
+  upstream.on('end', () => {
+    timings.total = Number(process.hrtime.bigint() - startAt);
+    responseView.body = Buffer.concat(respRaw);
+    if (!clientStream.closed) clientStream.end();
+    notify(entry);
+  });
+  upstream.on('error', (err) => {
+    logger.info('grpc upstream stream error', err);
+    entry.connectorError = err;
+    notify(entry);
+    if (!clientStream.closed) clientStream.close(http2.constants.NGHTTP2_INTERNAL_ERROR);
+  });
+}
+
+/** grpc-message is percent-encoded on the wire. */
+function grpcMessage(value: string | string[] | number | undefined): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/** Response headers to send downstream: keep :status, drop other pseudo + hop-by-hop. */
+function downstreamHeaders(respHeaders: http2.IncomingHttpHeaders): http2.OutgoingHttpHeaders {
+  const out: http2.OutgoingHttpHeaders = { ':status': respHeaders[':status'] ?? 200 };
+  for (const key of Object.keys(respHeaders)) {
+    if (key.startsWith(':') || HOP_BY_HOP.has(key)) continue;
+    out[key] = respHeaders[key];
+  }
+  return out;
+}

--- a/src/proxy/worker.ts
+++ b/src/proxy/worker.ts
@@ -3,11 +3,12 @@
 // restart is a cheap kill+respawn. Speaks typed messages with main over
 // process.parentPort.
 import { createProxyServer, type ProxyServer } from './core/server';
+import { createHttp2ProxyServer } from './core/http2';
 import { compileBreakpoints, matchBreakpoint, type CompiledBreakpoint } from './core/breakpoints';
 import { GrpcRegistry } from './core/grpc-registry';
 import type { RequestGate } from './core/server';
 import type { WorkerInbound, WorkerOutbound, BreakpointResume } from '../shared/ipc';
-import type { Logger, RequestParams } from '../shared/types';
+import type { Logger, RequestParams, TrafficEntry } from '../shared/types';
 
 // Electron's utilityProcess parentPort; typed loosely to keep this file free
 // of the electron module (it must be bundleable as a plain node entry).
@@ -63,15 +64,30 @@ async function start(msg: Extract<WorkerInbound, { type: 'start' }>): Promise<vo
     await server.close();
     server = null;
   }
-  const next = createProxyServer({
-    settings: msg.settings,
-    sslOptions: msg.sslOptions,
-    notify: (entry) => send({ type: 'traffic', entry }),
-    gate,
-    logger,
-    onServerError: (err) =>
-      send({ type: 'server-error', error: { code: err.code, message: err.message } }),
-  });
+  const onServerError = (err: NodeJS.ErrnoException): void =>
+    send({ type: 'server-error', error: { code: err.code, message: err.message } });
+  const notify = (entry: TrafficEntry): void => send({ type: 'traffic', entry });
+
+  // gRPC needs HTTP/2 + trailers, which the HTTP/1.1 server can't do. When
+  // enabled we run the HTTP/2 server and inject the proto registry so captured
+  // gRPC frames decode. (Breakpoints stay on the HTTP/1.1 path for now.)
+  const next = msg.settings.enableGrpc
+    ? createHttp2ProxyServer({
+        settings: msg.settings,
+        sslOptions: msg.sslOptions,
+        notify,
+        logger,
+        onServerError,
+        resolveMethod: (path) => grpcRegistry?.resolve(path),
+      })
+    : createProxyServer({
+        settings: msg.settings,
+        sslOptions: msg.sslOptions,
+        notify,
+        gate,
+        logger,
+        onServerError,
+      });
   const port = await next.listen();
   server = next;
   send({ type: 'started', port });

--- a/src/renderer/src/components/DetailPanes.tsx
+++ b/src/renderer/src/components/DetailPanes.tsx
@@ -1,12 +1,100 @@
 import { useState } from 'react';
 import * as Tabs from '@radix-ui/react-tabs';
-import { KeyRound } from 'lucide-react';
+import { Boxes, KeyRound } from 'lucide-react';
 import { useProxyStore } from '../stores/proxyStore';
 import { MonacoView, bodyToText } from './MonacoView';
 import { WithContextMenu } from './ui/ContextMenu';
 import { languageForContentType } from '../lib/content-type';
 import { findTokens, type FoundToken } from '../../../shared/decode';
-import type { RequestView, ResponseView, Timings } from '../../../shared/types';
+import type {
+  GrpcMessage,
+  GrpcView,
+  RequestView,
+  ResponseView,
+  Timings,
+} from '../../../shared/types';
+
+/** Human-readable gRPC status names for the common codes. */
+const GRPC_STATUS: Record<number, string> = {
+  0: 'OK',
+  1: 'CANCELLED',
+  2: 'UNKNOWN',
+  3: 'INVALID_ARGUMENT',
+  4: 'DEADLINE_EXCEEDED',
+  5: 'NOT_FOUND',
+  6: 'ALREADY_EXISTS',
+  7: 'PERMISSION_DENIED',
+  8: 'RESOURCE_EXHAUSTED',
+  9: 'FAILED_PRECONDITION',
+  10: 'ABORTED',
+  11: 'OUT_OF_RANGE',
+  12: 'UNIMPLEMENTED',
+  13: 'INTERNAL',
+  14: 'UNAVAILABLE',
+  15: 'DATA_LOSS',
+  16: 'UNAUTHENTICATED',
+};
+
+function GrpcMessageBlock({ msg, label }: { msg: GrpcMessage; label: string }): React.JSX.Element {
+  const body = msg.decodeError
+    ? `// decode failed: ${msg.decodeError}\n// ${msg.raw?.length ?? 0} raw bytes`
+    : msg.json !== undefined
+      ? JSON.stringify(msg.json, null, 2)
+      : `// no matching proto spec — ${msg.raw?.length ?? 0} raw bytes`;
+  return (
+    <div className="mb-3 rounded-md border border-neutral-200">
+      <div className="border-b border-neutral-100 px-3 py-1.5 text-xs font-medium text-neutral-600">
+        {label}
+        {msg.compressed && <span className="ml-2 text-neutral-400">compressed</span>}
+        {msg.decodeError && <span className="ml-2 text-red-600">decode error</span>}
+      </div>
+      <pre className="overflow-auto p-2.5 font-mono text-xs leading-5">{body}</pre>
+    </div>
+  );
+}
+
+function GrpcPane({ grpc }: { grpc: GrpcView }): React.JSX.Element {
+  const ok = grpc.status === 0;
+  const statusName = grpc.status !== undefined ? (GRPC_STATUS[grpc.status] ?? '') : undefined;
+  return (
+    <div className="h-full overflow-auto p-3">
+      <div className="mb-3 flex flex-wrap items-center gap-2 text-xs">
+        <span className="font-mono font-medium text-neutral-700">{grpc.method}</span>
+        {grpc.status !== undefined && (
+          <span className={ok ? 'text-emerald-700' : 'text-red-600'}>
+            status {grpc.status} {statusName}
+            {grpc.statusMessage ? ` — ${grpc.statusMessage}` : ''}
+          </span>
+        )}
+        {grpc.matchedSpecId === undefined && (
+          <span className="text-amber-600">no proto spec matched — import one to decode</span>
+        )}
+      </div>
+      <section className="mb-4">
+        <h4 className="mb-1.5 text-xs font-semibold uppercase text-neutral-500">
+          Request ({grpc.requestMessages.length})
+        </h4>
+        {grpc.requestMessages.map((m, i) => (
+          <GrpcMessageBlock key={i} msg={m} label={`message ${i + 1}`} />
+        ))}
+        {grpc.requestMessages.length === 0 && (
+          <p className="text-xs text-neutral-400">No request messages.</p>
+        )}
+      </section>
+      <section>
+        <h4 className="mb-1.5 text-xs font-semibold uppercase text-neutral-500">
+          Response ({grpc.responseMessages.length})
+        </h4>
+        {grpc.responseMessages.map((m, i) => (
+          <GrpcMessageBlock key={i} msg={m} label={`message ${i + 1}`} />
+        ))}
+        {grpc.responseMessages.length === 0 && (
+          <p className="text-xs text-neutral-400">No response messages.</p>
+        )}
+      </section>
+    </div>
+  );
+}
 
 function DecodedView({ tokens }: { tokens: FoundToken[] }): React.JSX.Element {
   return (
@@ -148,8 +236,18 @@ export function DetailPanes(): React.JSX.Element {
   const tokens = findTokens(entry);
 
   return (
-    <Tabs.Root defaultValue="response-body" className="flex h-full flex-col bg-white">
+    <Tabs.Root
+      defaultValue={entry.grpc ? 'grpc' : 'response-body'}
+      className="flex h-full flex-col bg-white"
+    >
       <Tabs.List className="flex border-b border-neutral-200 px-2" aria-label="Request details">
+        {entry.grpc && (
+          <Tabs.Trigger className={tabClass} value="grpc">
+            <span className="flex items-center gap-1">
+              <Boxes className="h-3.5 w-3.5" aria-hidden /> gRPC
+            </span>
+          </Tabs.Trigger>
+        )}
         <Tabs.Trigger className={tabClass} value="response-body">
           Response Body
         </Tabs.Trigger>
@@ -173,6 +271,11 @@ export function DetailPanes(): React.JSX.Element {
           </Tabs.Trigger>
         )}
       </Tabs.List>
+      {entry.grpc && (
+        <Tabs.Content value="grpc" className="min-h-0 grow">
+          <GrpcPane grpc={entry.grpc} />
+        </Tabs.Content>
+      )}
       <Tabs.Content value="response-body" className="min-h-0 grow">
         <BodyView view={entry.response} entryKey={`response-${selectedId}`} />
       </Tabs.Content>

--- a/src/renderer/src/components/SettingsBar.tsx
+++ b/src/renderer/src/components/SettingsBar.tsx
@@ -133,6 +133,18 @@ export function SettingsBar(): React.JSX.Element | null {
         onCommit={(port) => set({ destPort: port })}
         onValidity={(valid) => setInvalidPorts((p) => ({ ...p, dest: !valid }))}
       />
+      <label
+        className="flex items-center gap-1.5 text-sm text-neutral-600"
+        title="Run an HTTP/2 listener to proxy and decode gRPC. Import .proto/.desc under the gRPC menu."
+      >
+        <input
+          type="checkbox"
+          checked={settings.enableGrpc}
+          disabled={running}
+          onChange={(e) => set({ enableGrpc: e.target.checked })}
+        />
+        gRPC
+      </label>
       <div className="grow" />
       <button
         type="button"

--- a/src/renderer/src/components/TrafficTable.tsx
+++ b/src/renderer/src/components/TrafficTable.tsx
@@ -7,11 +7,23 @@ import { filterTraffic } from '../../../shared/traffic-query';
 import type { TrafficEntry } from '../../../shared/types';
 
 function statusClass(entry: TrafficEntry): string {
+  // For gRPC the HTTP status is 200 even on failure; the grpc-status trailer
+  // carries the real outcome (0 = OK).
+  if (entry.grpc?.status !== undefined) {
+    return entry.grpc.status === 0 ? 'text-emerald-700' : 'text-red-600';
+  }
   const code = entry.response.statusCode ?? 0;
   if (code >= 500) return 'text-red-600';
   if (code >= 400) return 'text-amber-600';
   if (code >= 300) return 'text-blue-600';
   return 'text-emerald-700';
+}
+
+/** Status cell text: gRPC status code when present, else the HTTP status. */
+function statusText(entry: TrafficEntry): string {
+  if (entry.connectorError) return 'ERR';
+  if (entry.grpc?.status !== undefined) return `gRPC ${entry.grpc.status}`;
+  return String(entry.response.statusCode ?? '');
 }
 
 function contentType(entry: TrafficEntry): string {
@@ -48,13 +60,19 @@ const Row = memo(function Row({
         {entry.trafficId}
         {entry.replay ? ' ↺' : ''}
       </td>
-      <td className="px-3 py-1.5 font-medium">{entry.request.method}</td>
+      <td className="px-3 py-1.5 font-medium">
+        {entry.grpc ? (
+          <span className="rounded bg-indigo-100 px-1.5 py-0.5 text-xs font-semibold text-indigo-700">
+            gRPC
+          </span>
+        ) : (
+          entry.request.method
+        )}
+      </td>
       <td className="max-w-0 truncate px-3 py-1.5" title={entry.request.url}>
         {entry.request.url}
       </td>
-      <td className={`px-3 py-1.5 font-medium ${statusClass(entry)}`}>
-        {entry.connectorError ? 'ERR' : (entry.response.statusCode ?? '')}
-      </td>
+      <td className={`px-3 py-1.5 font-medium ${statusClass(entry)}`}>{statusText(entry)}</td>
       <td className="truncate px-3 py-1.5 text-neutral-500">{contentType(entry)}</td>
     </tr>
   );

--- a/src/shared/settings-schema.ts
+++ b/src/shared/settings-schema.ts
@@ -21,6 +21,8 @@ export interface AppSettings {
   mcpEnabled: boolean;
   /** Allow MCP clients to start/stop/configure the proxy. */
   mcpAllowControl: boolean;
+  /** Run an HTTP/2 listener so native gRPC can be proxied and decoded. */
+  enableGrpc: boolean;
 }
 
 export const defaultSettings: AppSettings = {
@@ -50,6 +52,8 @@ export const defaultSettings: AppSettings = {
   // The socket is same-user-only and read-only unless control is enabled.
   mcpEnabled: true,
   mcpAllowControl: false,
+  // Off by default: only gRPC users need the HTTP/2 listener.
+  enableGrpc: false,
 };
 
 export function isValidPort(value: unknown): value is number {
@@ -82,6 +86,7 @@ export function sanitizeSettingsPatch(patch: unknown): Partial<AppSettings> {
     'allowSelfSignedUpstream',
     'mcpEnabled',
     'mcpAllowControl',
+    'enableGrpc',
   ] as const) {
     if (typeof p[key] === 'boolean') out[key] = p[key];
   }
@@ -106,5 +111,6 @@ export function toProxySettings(s: AppSettings): ProxySettings {
     interceptRequest: s.interceptRequest,
     responseInterceptor: s.responseInterceptor,
     interceptResponse: s.interceptResponse,
+    enableGrpc: s.enableGrpc,
   };
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -22,6 +22,12 @@ export interface ProxySettings {
   interceptRequest?: boolean;
   responseInterceptor?: string;
   interceptResponse?: boolean;
+  /**
+   * Run an HTTP/2 listener so native gRPC can be proxied and decoded. When the
+   * listen protocol is https the server negotiates h2 via ALPN (HTTP/1.1 still
+   * works); when http it speaks cleartext h2c (prior knowledge).
+   */
+  enableGrpc?: boolean;
 }
 
 /** Parameters of the upstream request; mutated by request interceptors. */

--- a/tests/unit/grpc-proxy.test.mjs
+++ b/tests/unit/grpc-proxy.test.mjs
@@ -1,0 +1,172 @@
+// Integration test: a real gRPC round-trip through createHttp2ProxyServer.
+// A hand-rolled HTTP/2 (h2c) upstream speaks gRPC framing + trailers; the proxy
+// forwards it and decodes messages against injected proto types. Covers unary,
+// server-streaming, and a non-OK grpc-status, asserting decoded JSON both ways,
+// the captured grpc-status trailer, and byte-exact raw passthrough.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http2 from 'node:http2';
+import protobuf from 'protobufjs';
+import { createHttp2ProxyServer } from '../../src/proxy/core/http2';
+import { encodeGrpcFrame, parseGrpcFrames } from '../../src/proxy/core/grpc-frames';
+
+const PROTO = `
+  syntax = "proto3";
+  package test;
+  message EchoRequest { string text = 1; }
+  message EchoReply { string text = 1; }
+  service Echo {
+    rpc Unary (EchoRequest) returns (EchoReply);
+    rpc ServerStream (EchoRequest) returns (stream EchoReply);
+    rpc Boom (EchoRequest) returns (EchoReply);
+  }
+`;
+
+const root = protobuf.parse(PROTO).root;
+root.resolveAll();
+const EchoRequest = root.lookupType('test.EchoRequest');
+const EchoReply = root.lookupType('test.EchoReply');
+
+const reqFrame = (text) => encodeGrpcFrame(Buffer.from(EchoRequest.encode({ text }).finish()));
+const replyFrame = (text) => encodeGrpcFrame(Buffer.from(EchoReply.encode({ text }).finish()));
+
+function listen(server) {
+  return new Promise((resolve) => server.listen(0, '127.0.0.1', () => resolve(server.address().port)));
+}
+
+// A minimal gRPC server over h2c that reads the request message and replies
+// per method, finishing with a grpc-status trailer.
+function startGrpcUpstream() {
+  const server = http2.createServer();
+  server.on('stream', (stream, headers) => {
+    const path = headers[':path'];
+    const chunks = [];
+    stream.on('data', (c) => chunks.push(c));
+    stream.on('end', () => {
+      const [frame] = parseGrpcFrames(Buffer.concat(chunks)).frames;
+      const name = EchoRequest.decode(frame.data).text;
+
+      if (path === '/test.Echo/Boom') {
+        // Trailers-Only: status rides in the response HEADERS, END_STREAM.
+        stream.respond(
+          { ':status': '200', 'content-type': 'application/grpc', 'grpc-status': '5', 'grpc-message': 'not found' },
+          { endStream: true }
+        );
+        return;
+      }
+
+      stream.respond({ ':status': '200', 'content-type': 'application/grpc+proto' }, { waitForTrailers: true });
+      stream.on('wantTrailers', () => stream.sendTrailers({ 'grpc-status': '0', 'grpc-message': 'OK' }));
+
+      if (path === '/test.Echo/ServerStream') {
+        for (let i = 1; i <= 3; i++) stream.write(replyFrame(`${name} #${i}`));
+      } else {
+        stream.write(replyFrame(`hello ${name}`));
+      }
+      stream.end();
+    });
+  });
+  return listen(server).then((port) => ({ server, port }));
+}
+
+// Drives one gRPC call as an h2c client; resolves with response frames + trailers.
+function grpcCall(port, path, text) {
+  return new Promise((resolve, reject) => {
+    const session = http2.connect(`http://127.0.0.1:${port}`);
+    session.on('error', reject);
+    const stream = session.request({
+      ':method': 'POST',
+      ':path': path,
+      'content-type': 'application/grpc+proto',
+      te: 'trailers',
+    });
+    const chunks = [];
+    let trailers = {};
+    let status;
+    stream.on('response', (h) => {
+      status = Number(h[':status']);
+      if (h['grpc-status'] !== undefined) trailers = h; // Trailers-Only
+    });
+    stream.on('trailers', (t) => {
+      trailers = t;
+    });
+    stream.on('data', (c) => chunks.push(c));
+    stream.on('end', () => {
+      session.close();
+      const messages = parseGrpcFrames(Buffer.concat(chunks)).frames.map((f) => EchoReply.decode(f.data).text);
+      resolve({ status, messages, trailers, raw: Buffer.concat(chunks) });
+    });
+    stream.on('error', reject);
+    stream.end(reqFrame(text));
+  });
+}
+
+const resolveMethod = (path) =>
+  path.startsWith('/test.Echo/') ? { specId: 's1', requestType: EchoRequest, responseType: EchoReply } : undefined;
+
+let upstream;
+let proxy;
+let proxyPort;
+const entries = new Map(); // trafficId -> latest entry (the store upserts the same way)
+
+beforeAll(async () => {
+  upstream = await startGrpcUpstream();
+  proxy = createHttp2ProxyServer({
+    settings: {
+      listenProtocol: 'http',
+      listenPort: 0,
+      destProtocol: 'http',
+      dest: '127.0.0.1',
+      destPort: upstream.port,
+      allowSelfSignedUpstream: true,
+      enableGrpc: true,
+    },
+    notify: (entry) => entries.set(entry.trafficId, entry),
+    resolveMethod,
+  });
+  proxyPort = await proxy.listen();
+});
+
+afterAll(async () => {
+  await proxy.close();
+  upstream.server.close();
+});
+
+function latestFor(path) {
+  return [...entries.values()].filter((e) => e.grpc?.method === path).at(-1);
+}
+
+describe('gRPC over the HTTP/2 proxy', () => {
+  it('proxies and decodes a unary call', async () => {
+    const res = await grpcCall(proxyPort, '/test.Echo/Unary', 'ada');
+    expect(res.status).toBe(200);
+    expect(res.messages).toEqual(['hello ada']);
+    expect(String(res.trailers['grpc-status'])).toBe('0');
+
+    const entry = latestFor('/test.Echo/Unary');
+    expect(entry.grpc.requestMessages.map((m) => m.json.text)).toEqual(['ada']);
+    expect(entry.grpc.responseMessages.map((m) => m.json.text)).toEqual(['hello ada']);
+    expect(entry.grpc.status).toBe(0);
+    expect(entry.grpc.matchedSpecId).toBe('s1');
+  });
+
+  it('decodes every message of a server-streaming call', async () => {
+    const res = await grpcCall(proxyPort, '/test.Echo/ServerStream', 'bob');
+    expect(res.messages).toEqual(['bob #1', 'bob #2', 'bob #3']);
+
+    const entry = latestFor('/test.Echo/ServerStream');
+    expect(entry.grpc.responseMessages.map((m) => m.json.text)).toEqual(['bob #1', 'bob #2', 'bob #3']);
+    expect(entry.grpc.status).toBe(0);
+    // Raw response bytes pass through byte-for-byte.
+    const reframed = Buffer.concat([replyFrame('bob #1'), replyFrame('bob #2'), replyFrame('bob #3')]);
+    expect(Buffer.compare(res.raw, reframed)).toBe(0);
+  });
+
+  it('captures a non-OK grpc-status (Trailers-Only)', async () => {
+    const res = await grpcCall(proxyPort, '/test.Echo/Boom', 'x');
+    expect(String(res.trailers['grpc-status'])).toBe('5');
+
+    const entry = latestFor('/test.Echo/Boom');
+    expect(entry.grpc.status).toBe(5);
+    expect(entry.grpc.statusMessage).toBe('not found');
+  });
+});


### PR DESCRIPTION
## Summary

Completes gRPC support. On top of the M1 spec-management + decode engine (already on `main`), this adds the **HTTP/2 transport** that proxies native gRPC and decodes every message live — **unary and server/client/bidi streaming** (M2 + M3 together).

## How it works

- **`src/proxy/core/http2.ts`** (Electron-free) — runs when the new `enableGrpc` setting is on (default off), replacing the HTTP/1.1 server. `https` negotiates **h2 via ALPN**; `http` speaks **cleartext h2c** (prior knowledge).
- Per stream it opens an upstream HTTP/2 stream, **pipes bytes both ways unmodified**, and copies frames through a `FrameAccumulator` to decode messages **as they arrive** — so streaming calls fill in incrementally. The `TrafficEntry` is re-emitted per frame (the store upserts by `trafficId`).
- Captures the **`grpc-status` / `grpc-message` trailer**, including gRPC **Trailers-Only** responses (status in the response HEADERS).
- The worker routes to `createHttp2ProxyServer` when `enableGrpc` and injects the proto registry's `resolveMethod` so frames decode against saved specs.

gRPC mode is **HTTP/2-only** on that port: mixing the native stream API (needed for trailers) with the HTTP/1.1 compatibility layer double-sends trailers.

## UI

- A **gRPC** toggle in the settings bar.
- Traffic table: a **gRPC** badge and `grpc-status`-based row colouring (HTTP is 200 even on gRPC failure).
- Detail pane: a **gRPC** tab rendering each request/response message as JSON (with status name) next to the raw bytes; every streamed message is listed.

## Testing

- **`tests/unit/grpc-proxy.test.mjs`** — full round-trip through `createHttp2ProxyServer` against a hand-rolled h2c gRPC upstream: **unary, server-streaming, and a non-OK Trailers-Only status**, asserting decoded JSON both ways, the captured `grpc-status`, and byte-exact raw passthrough.
- `npm run lint` ✅ · `npm run typecheck` ✅ · `npm test` ✅ (119) · `npx playwright test` ✅ (10) · `npm run build` ✅ (http2 + protobufjs reachable from the forked worker).

## Docs

README, `docs/{architecture,features,llms.txt}`, and TESTING updated — gRPC is now a shipped capability, not a roadmap note.

## Follow-up (not in this PR)

- An app-level gRPC e2e (drive a real gRPC client through the running app) — the transport is covered by the integration test; this would add UI-level coverage.
- Breakpoint gating currently stays on the HTTP/1.1 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)